### PR TITLE
Document inclusion of the Maplibre Native license. (fixes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,7 @@ Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the
 Apache-2.0 license, shall be dual licensed as above, without any
 additional terms or conditions.
+
+### MapLibre Native Licence
+
+Because this crate downloads and statically links against MapLibre Native assets during `cargo build`, dependent projects are encouaged to include the [MapLibre Native License](https://github.com/maplibre/maplibre-native/blob/main/LICENSE.md) with their code to satisfy the BSD 2-Clause License requirements on binary redistribution.


### PR DESCRIPTION
This PR addresses licensing concerns in `README.md`.

As I understand the BSD 2-Clause, `maplibre-native-rs` is not required to include the MapLibre Native license, since binary and source artifacts are downloaded to the host machine during `cargo build`, and thus are not "redistributed" by the crate as far as the license is concerned.

On the other hand, any project building against this crate _would_ need to include the license with any binary release, since these would technically be "redistributing" the binary code against which they were linked.

fixes #5 
