### PR TITLE
revised wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ additional terms or conditions.
 
 ### MapLibre Native Licence
 
-Because this crate downloads and statically links against MapLibre Native assets during `cargo build`, dependent projects are encouaged to include the [MapLibre Native License](https://github.com/maplibre/maplibre-native/blob/main/LICENSE.md) with their code to satisfy the BSD 2-Clause License requirements on binary redistribution.
+Because this crate downloads and statically links against MapLibre Native assets during `cargo build`, dependent projects should include the [MapLibre Native License](https://github.com/maplibre/maplibre-native/blob/main/LICENSE.md) with their code to satisfy the BSD 2-Clause License requirements on binary redistribution.

--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ additional terms or conditions.
 
 ### MapLibre Native Licence
 
-Because this crate downloads and statically links against MapLibre Native assets during `cargo build`, dependent projects should include the [MapLibre Native License](https://github.com/maplibre/maplibre-native/blob/main/LICENSE.md) with their code to satisfy the BSD 2-Clause License requirements on binary redistribution.
+This crate incorporates MapLibre Native assets during compilation by downloading and statically linking them. As a result, any project using this crate must comply with the [MapLibre Native License](https://github.com/maplibre/maplibre-native/blob/main/LICENSE.md) (BSD 2-Clause) requirements for binary distribution. This includes providing proper attribution and including the license text with your distributed binaries or source code.


### PR DESCRIPTION
fix "encouraged" misspelling and use "should" instead. Good middle ground between "encouraged" (weak) and "required" (strict). "Required" may also be a bit too heavy-handed without consulting an actual lawyer, and "should" covers the bases well.
