### PR TITLE
chore(ci): add a step to require conventional pr titles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   release:
-    types: [ published ]
+    types: [published]
   workflow_dispatch:
 
 defaults:
@@ -14,6 +14,15 @@ defaults:
     shell: bash
 
 jobs:
+  pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -21,7 +30,7 @@ jobs:
       - run: rustup update stable && rustup default stable
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2
-        with: { tool: 'just' }
+        with: { tool: "just" }
       - uses: Swatinem/rust-cache@v2
       - run: just ci-lint
   test:
@@ -54,7 +63,7 @@ jobs:
       - run: rustup update stable && rustup default stable
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2
-        with: { tool: 'just' }
+        with: { tool: "just" }
       - uses: Swatinem/rust-cache@v2
       - name: Install linux dependencies
         if: startsWith(matrix.runs-on, 'ubuntu')
@@ -123,7 +132,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2
-        with: { tool: 'just' }
+        with: { tool: "just" }
       - if: github.event_name == 'release'
         name: Ensure this crate has not yet been published (on release)
         run: just check-if-published
@@ -147,7 +156,7 @@ jobs:
   done:
     name: CI Finished
     runs-on: ubuntu-latest
-    needs: [ release ]
+    needs: [ release, pr-title ]
     if: always()
     steps:
       - name: Result of the needed steps


### PR DESCRIPTION
If we add release-plz, we likely want a new step in the CI that asserts that PR-titles are formatted with [conventional commit messages](https://flank.github.io/flank/pr_titles/).