### PR TITLE
chore(ci): Make sure that msrv is a separate step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: just ci-lint
   test:
-    name: Test ${{ matrix.runs-on }} - ${{ matrix.backend }}
+    name: Test ${{ matrix.runs-on }} - ${{ matrix.backend }} - rust@${{ matrix.rust-version }}
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,24 +38,45 @@ jobs:
           # Linux x86
           - runs-on: ubuntu-latest
             backend: vulkan
+            rust-version: stable
+          - runs-on: ubuntu-latest
+            backend: vulkan
+            rust-version: msrv
           - runs-on: ubuntu-latest
             backend: opengl
+            rust-version: stable
+          - runs-on: ubuntu-latest
+            backend: opengl
+            rust-version: msrv
 
           # Linux ARM
           - runs-on: ubuntu-24.04-arm
             backend: vulkan
+            rust-version: stable
           - runs-on: ubuntu-24.04-arm
             backend: opengl
+            rust-version: msrv
 
           # macOS ARM
           #- runs-on: macos-latest
           #  backend: metal
+          #  rust-version: stable
+          #- runs-on: macos-latest
+          #  backend: metal
+          #  rust-version: msrv
           #- runs-on: macos-latest
           #  backend: vulkan
+          #  rust-version: stable
+          #- runs-on: macos-latest
+          #  backend: vulkan
+          #  rust-version: msrv
           #- runs-on: macos-latest
           #  backend: opengl
+          #  rust-version: stable
+          #- runs-on: macos-latest
+          #  backend: opengl
+          #  rust-version: msrv
     steps:
-      - run: rustup update stable && rustup default stable
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2
         with: { tool: 'just' }
@@ -97,30 +118,21 @@ jobs:
           if [ "${{ matrix.backend }}" = "vulkan" ]; then
             brew install molten-vk vulkan-headers
           fi
-      # Regular tests
-      - run: just ci-test ${{ matrix.backend }}
-      - run: just test-doc ${{ matrix.backend }}
-      # Test MSRV
+      # Setup rust version
+      - run: rustup update stable && rustup default stable
+        if: matrix.rust-version == 'stable'
       - name: Read MSRV
         id: msrv
         run: echo "value=$(sed -nE 's/^rust-version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+        if: matrix.rust-version == 'msrv'
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.msrv.outputs.value }}
+        if: matrix.rust-version == 'msrv'
+      # Run tests
       - run: just ci-test ${{ matrix.backend }}
-      # Test MIRI
-      # Currently disabled due to "unsupported operation: can't call foreign function `mln$bridge$cxxbridge1$MapRenderer_new` on OS `linux`"
-      # Needs reinvestigation if this can be fixed via "-Zmiri-native-lib" or maybe "-Zmiri-native-lib-enable-tracing"
-      # Tracking issue upstream https://github.com/rust-lang/miri/issues/11
-      # - run: |
-      #     echo "NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> "$GITHUB_ENV"
-      # - name: Install ${{ env.NIGHTLY }}
-      #   uses: dtolnay/rust-toolchain@master
-      #   with:
-      #     toolchain: ${{ env.NIGHTLY }}
-      #     components: miri
-      # - run: just test-miri ${{ matrix.backend }}
+      - run: just test-doc ${{ matrix.backend }}
   release:
     needs: [test, lint]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,6 @@ jobs:
         if: matrix.rust-version == 'msrv'
       # Run tests
       - run: just ci-test ${{ matrix.backend }}
-      - run: just test-doc ${{ matrix.backend }}
   release:
     needs: [test, lint]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
       - uses: taiki-e/install-action@v2
         with: { tool: 'just' }
       - uses: Swatinem/rust-cache@v2
-      - name: Install linux dependencies
-        if: startsWith(matrix.runs-on, 'ubuntu')
+      - if: startsWith(matrix.runs-on, 'ubuntu')
+        name: Install linux dependencies
         run: |
           sudo apt-get update
           # Make sure this list matches README
@@ -101,8 +101,8 @@ jobs:
           elif [ "${{ matrix.backend }}" = "vulkan" ]; then
             sudo apt-get install -y mesa-vulkan-drivers glslang-dev
           fi
-      - name: Install macOS dependencies
-        if: startsWith(matrix.runs-on, 'macos')
+      - if: startsWith(matrix.runs-on, 'macos')
+        name: Install macOS dependencies
         run: |
           # Install dependencies via Homebrew
           brew install \
@@ -119,17 +119,17 @@ jobs:
             brew install molten-vk vulkan-headers
           fi
       # Setup rust version
-      - run: rustup update stable && rustup default stable
-        if: matrix.rust-version == 'stable'
-      - name: Read MSRV
+      - if: matrix.rust-version == 'stable'
+        run: rustup update stable && rustup default stable
+      - if: matrix.rust-version == 'msrv'
+        name: Read MSRV
         id: msrv
         run: echo "value=$(sed -nE 's/^rust-version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
-        if: matrix.rust-version == 'msrv'
-      - name: Install Rust
+      - if: matrix.rust-version == 'msrv'
+        name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.msrv.outputs.value }}
-        if: matrix.rust-version == 'msrv'
       # Run tests
       - run: just ci-test ${{ matrix.backend }}
   release:
@@ -160,10 +160,10 @@ jobs:
   # This final step is needed to mark the whole workflow as successful
   # Don't change its name - it is used by the merge protection rules
   done:
+    if: always()
+    needs: [ release ]
     name: CI Finished
     runs-on: ubuntu-latest
-    needs: [ release ]
-    if: always()
     steps:
       - name: Result of the needed steps
         run: echo "${{ toJSON(needs) }}"


### PR DESCRIPTION
Our CI is currently a bit sluggish.
This is partially because we don't abuse the paralelism that we can use to the extent that we might.

with this PR, we now have:
- 1 linting
- 4 linux-x86 tests
- 4 linux-arm tests
- (not active, requires other PR) 6 macos tests

=> 15/20 runners

This PR makes sure that the msrv runs are in a separate step of the CI