### PR TITLE
Document windows x86 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ If no feature is specified, the crate will automatically select the platform-app
 
 The following platform and rendering-API combinations are supported and tested in CI:
 
-| Platform  | Metal | Vulkan | OpenGL |
-| --------- | ----- | ------ | ------ |
-| Linux x86 | ❌    | ✅     | ✅     |
-| Linux ARM | ❌    | ✅     | ✅     |
-| macOS ARM | 🟨    | 🟨[^1] | ❌     |
+| Platform    | Metal | Vulkan | OpenGL |
+| ----------- | ----- | ------ | ------ |
+| Linux x86   | ❌    | ✅     | ✅     |
+| Linux ARM   | ❌    | ✅     | ✅     |
+| Windows x86 | ❌    | 🟨     | 🟨     |
+| macOS ARM   | 🟨    | 🟨[^1] | ❌     |
 
 <sub>
 ✅ = IS supported and tested in CI


### PR DESCRIPTION
MLN currently publishes windows x86 libraries, so that part at least is likely planned.
No clue for arm on windows, we will see.