### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.1.2...v0.2.0) - 2025-09-23
+
+### Fixed
+
+- *(api)* clearer style rendering semantics ([#63](https://github.com/maplibre/maplibre-native-rs/pull/63))
+
+### Other
+
+- *(deps)* bump the all-actions-version-updates group with 2 updates ([#62](https://github.com/maplibre/maplibre-native-rs/pull/62))
+
 ## [0.1.2](https://github.com/maplibre/maplibre-native-rs/compare/v0.1.1...v0.1.2) - 2025-09-18
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.1.2"
+version = "0.2.0"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -56,7 +56,7 @@ cxx = "1.0.138"
 cxx-build = "1.0.138"
 downloader = "0.2.8"
 flate2 = "1.1.1"
-maplibre_native = { path = ".", version = "0.1.2" }
+maplibre_native = { path = ".", version = "0.2.0" }
 tar = "0.4.44"
 walkdir = "2.5.0"
 


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `maplibre_native` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  ImageRenderer::set_style_url, previously in file /tmp/.tmpy7q9Ni/maplibre_native/src/renderer/image_renderer.rs:36
  ImageRenderer::set_style_path, previously in file /tmp/.tmpy7q9Ni/maplibre_native/src/renderer/image_renderer.rs:43
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.1.2...v0.2.0) - 2025-09-23

### Fixed

- *(api)* clearer style rendering semantics ([#63](https://github.com/maplibre/maplibre-native-rs/pull/63))

### Other

- *(deps)* bump the all-actions-version-updates group with 2 updates ([#62](https://github.com/maplibre/maplibre-native-rs/pull/62))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).