### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - *(renderer)* refactored parts of the public API to be nicer to work with and less error prawn ([#66](https://github.com/maplibre/maplibre-native-rs/pull/66))
-- logging ([#71](https://github.com/maplibre/maplibre-native-rs/pull/71))
+- *(renderer)* logging via `log` from maplibre-native ([#71](https://github.com/maplibre/maplibre-native-rs/pull/71))
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.2.0...v0.3.0) - 2025-09-25
+
+### Added
+
+- *(renderer)* refactored parts of the public API to be nicer to work with and less error prawn ([#66](https://github.com/maplibre/maplibre-native-rs/pull/66))
+- logging ([#71](https://github.com/maplibre/maplibre-native-rs/pull/71))
+
+### Other
+
+- *(renderer)* Add more derives and rename conversation function on `Image` ([#73](https://github.com/maplibre/maplibre-native-rs/pull/73))
+- *(ci)* change to `secrets.GITHUB_TOKEN` instead of our manual secret ([#67](https://github.com/maplibre/maplibre-native-rs/pull/67))
+- sort toml files ([#70](https://github.com/maplibre/maplibre-native-rs/pull/70))
+
 ## [0.2.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.1.2...v0.2.0) - 2025-09-23
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.2.0"
+version = "0.3.0"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -64,7 +64,7 @@ downloader = "0.2.8"
 env_logger = "0.11"
 flate2 = "1.1.1"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.2.0" }
+maplibre_native = { path = ".", version = "0.3.0" }
 tar = "0.4.44"
 thiserror = "2.0.16"
 url = "2.5.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,4 @@
 #![allow(unused)]
 
 mod renderer;
-
 pub use renderer::*;

--- a/src/renderer/image_renderer.rs
+++ b/src/renderer/image_renderer.rs
@@ -73,6 +73,7 @@ impl<S> ImageRenderer<S> {
                 format!("Path {} is not valid UTF-8", path.display()),
             ));
         };
+        self.style_specified = true;
         ffi::MapRenderer_getStyle_loadURL(self.instance.pin_mut(), &format!("file://{path}"));
         Ok(self)
     }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -3,5 +3,5 @@ mod image_renderer;
 mod options;
 
 pub use bridge::ffi::{MapDebugOptions, MapMode};
-pub use image_renderer::{Image, ImageRenderer, Static, Tile};
+pub use image_renderer::{Image, ImageRenderer, RenderingError, Static, Tile};
 pub use options::ImageRendererOptions;


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `maplibre_native` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  Image::as_slice, previously in file /tmp/.tmpdkpau1/maplibre_native/src/renderer/image_renderer.rs:17
  ImageRenderer::set_camera, previously in file /tmp/.tmpdkpau1/maplibre_native/src/renderer/image_renderer.rs:54

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_parameter_count_changed.ron

Failed in:
  maplibre_native::ImageRenderer::render_static now takes 6 parameters instead of 1, in /tmp/.tmpjzO7OS/maplibre-native-rs/src/renderer/image_renderer.rs:92
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.2.0...v0.3.0) - 2025-09-25

### Added

- *(renderer)* refactored parts of the public API to be nicer to work with and less error prawn ([#66](https://github.com/maplibre/maplibre-native-rs/pull/66))
- logging ([#71](https://github.com/maplibre/maplibre-native-rs/pull/71))

### Other

- *(renderer)* Add more derives and rename conversation function on `Image` ([#73](https://github.com/maplibre/maplibre-native-rs/pull/73))
- *(ci)* change to `secrets.GITHUB_TOKEN` instead of our manual secret ([#67](https://github.com/maplibre/maplibre-native-rs/pull/67))
- sort toml files ([#70](https://github.com/maplibre/maplibre-native-rs/pull/70))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).