### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.3.0...v0.3.1) - 2025-09-26
+
+### Added
+
+- *(pool)* Add a single-threaded image rendering pool ([#68](https://github.com/maplibre/maplibre-native-rs/pull/68))
+
+### Fixed
+
+- *(release)* Revert permission change for CI ([#74](https://github.com/maplibre/maplibre-native-rs/pull/74))
+
+### Other
+
+- *(release)* another test if we can reduce our permissions for releases ([#75](https://github.com/maplibre/maplibre-native-rs/pull/75))
+
 ## [0.3.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.2.0...v0.3.0) - 2025-09-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.3.0"
+version = "0.3.1"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -71,7 +71,7 @@ flate2 = "1.1.1"
 futures = "0.3"
 insta = "1.43.2"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.3.0" }
+maplibre_native = { path = ".", version = "0.3.1" }
 tar = "0.4.44"
 thiserror = "2.0.16"
 tokio = { version = "1", features = ["sync"], default-features = false }


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.3.0...v0.3.1) - 2025-09-26

### Added

- *(pool)* Add a single-threaded image rendering pool ([#68](https://github.com/maplibre/maplibre-native-rs/pull/68))

### Fixed

- *(release)* Revert permission change for CI ([#74](https://github.com/maplibre/maplibre-native-rs/pull/74))

### Other

- *(release)* another test if we can reduce our permissions for releases ([#75](https://github.com/maplibre/maplibre-native-rs/pull/75))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).