### PR TITLE
chore(ci): trigger PR title workflow on synchronize event

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,6 +8,7 @@ on:
       - opened
       - edited
       - reopened
+      - synchronize
 
 jobs:
   pr-title:


### PR DESCRIPTION
it seems that this event is needed for the workflow to consistently trigger.

The syncronise event seems to be merge commits => why https://github.com/maplibre/martin/pull/2255 did not merge