### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.3.1...v0.4.0) - 2025-10-02
+
+### Added
+
+- *(pool)* add an example how to use the pool ([#88](https://github.com/maplibre/maplibre-native-rs/pull/88))
+- *(renderer)* [**breaking**] Rework the builder interface and document it ([#85](https://github.com/maplibre/maplibre-native-rs/pull/85))
+- *(renderer)* Rework the image rendering API ([#82](https://github.com/maplibre/maplibre-native-rs/pull/82))
+
+### Other
+
+- *(lints)* Remove unused variables ([#84](https://github.com/maplibre/maplibre-native-rs/pull/84))
+- *(deps)* update image requirement from 0.24 to 0.25 in the all-cargo-version-updates group ([#86](https://github.com/maplibre/maplibre-native-rs/pull/86))
+- add MapLibre Contributors to the authors ([#81](https://github.com/maplibre/maplibre-native-rs/pull/81))
+- *(deps)* bump taiki-e/install-action from 2.62.0 to 2.62.11 in the all-actions-version-updates group ([#79](https://github.com/maplibre/maplibre-native-rs/pull/79))
+- *(ci)* trigger PR title workflow on synchronize event ([#77](https://github.com/maplibre/maplibre-native-rs/pull/77))
+
 ## [0.3.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.3.0...v0.3.1) - 2025-09-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.3.1"
+version = "0.4.0"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -74,7 +74,7 @@ futures = "0.3"
 image = "0.25"
 insta = "1.43.2"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.3.1" }
+maplibre_native = { path = ".", version = "0.4.0" }
 tar = "0.4.44"
 thiserror = "2.0.16"
 tokio = { version = "1", features = [], default-features = false }


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `maplibre_native` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_added.ron

Failed in:
  variant RenderingError:InvalidImageData in /tmp/.tmpi9nzye/maplibre-native-rs/src/renderer/image_renderer.rs:179

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  Image::as_bytes, previously in file /tmp/.tmpqQxvU0/maplibre_native/src/renderer/image_renderer.rs:28

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct maplibre_native::ImageRendererOptions, previously in file /tmp/.tmpqQxvU0/maplibre_native/src/renderer/options.rs:9
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.3.1...v0.4.0) - 2025-10-02

### Added

- *(pool)* add an example how to use the pool ([#88](https://github.com/maplibre/maplibre-native-rs/pull/88))
- *(renderer)* [**breaking**] Rework the builder interface and document it ([#85](https://github.com/maplibre/maplibre-native-rs/pull/85))
- *(renderer)* Rework the image rendering API ([#82](https://github.com/maplibre/maplibre-native-rs/pull/82))

### Other

- *(lints)* Remove unused variables ([#84](https://github.com/maplibre/maplibre-native-rs/pull/84))
- *(deps)* update image requirement from 0.24 to 0.25 in the all-cargo-version-updates group ([#86](https://github.com/maplibre/maplibre-native-rs/pull/86))
- add MapLibre Contributors to the authors ([#81](https://github.com/maplibre/maplibre-native-rs/pull/81))
- *(deps)* bump taiki-e/install-action from 2.62.0 to 2.62.11 in the all-actions-version-updates group ([#79](https://github.com/maplibre/maplibre-native-rs/pull/79))
- *(ci)* trigger PR title workflow on synchronize event ([#77](https://github.com/maplibre/maplibre-native-rs/pull/77))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).