### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.4.0...v0.4.1) - 2025-10-06
+
+### Other
+
+- do a docs pass around the readme and doc comments ([#87](https://github.com/maplibre/maplibre-native-rs/pull/87))
+- *(deps)* bump taiki-e/install-action from 2.62.11 to 2.62.20 in the all-actions-version-updates group ([#89](https://github.com/maplibre/maplibre-native-rs/pull/89))
+
 ## [0.4.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.3.1...v0.4.0) - 2025-10-02
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.4.0"
+version = "0.4.1"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -74,7 +74,7 @@ futures = "0.3"
 image = "0.25"
 insta = "1.43.2"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.4.0" }
+maplibre_native = { path = ".", version = "0.4.1" }
 tar = "0.4.44"
 thiserror = "2.0.16"
 tokio = { version = "1", features = [], default-features = false }


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.4.0...v0.4.1) - 2025-10-06

### Other

- do a docs pass around the readme and doc comments ([#87](https://github.com/maplibre/maplibre-native-rs/pull/87))
- *(deps)* bump taiki-e/install-action from 2.62.11 to 2.62.20 in the all-actions-version-updates group ([#89](https://github.com/maplibre/maplibre-native-rs/pull/89))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).