### PR TITLE
chore(renderer): Support floating-point lat/lon values in renderer example

### DIFF
--- a/examples/render/src/main.rs
+++ b/examples/render/src/main.rs
@@ -2,7 +2,6 @@
 //!
 //! This example demonstrates how to use the different rendering options
 //! including different map styles, zoom levels, and output formats.
-//! including different map styles, zoom levels, and output formats.
 //!
 //! For exapmle create a image of a specific tile with `cargo run -- -m tile -z 3 -x 4 -y 2`
 //! or of a specific area (uses lat,lon and zoom) `cargo run -- --zoom 3.9 --lat 17.209 --lon -87.41`

--- a/examples/render/src/main.rs
+++ b/examples/render/src/main.rs
@@ -157,12 +157,8 @@ impl Args {
 
         match self.mode {
             Mode::Static => {
-                if !(-90.0..=90.0).contains(&self.lat) {
-                    panic!("lat must be between -90 and 90")
-                }
-                if !(-180.0..=180.0).contains(&self.lon) {
-                    panic!("lon must be between -180 and 180")
-                }
+                assert!((-90.0..=90.0).contains(&self.lat), "lat must be between -90 and 90");
+                assert!((-180.0..=180.0).contains(&self.lon), "lon must be between -180 and 180");
 
                 let mut map = map.build_static_renderer();
                 if let Some(debug) = self.debug {

--- a/examples/render/src/main.rs
+++ b/examples/render/src/main.rs
@@ -157,8 +157,14 @@ impl Args {
 
         match self.mode {
             Mode::Static => {
-                assert!((-90.0..=90.0).contains(&self.lat), "lat must be between -90 and 90");
-                assert!((-180.0..=180.0).contains(&self.lon), "lon must be between -180 and 180");
+                assert!(
+                    (-90.0..=90.0).contains(&self.lat),
+                    "lat must be between -90 and 90"
+                );
+                assert!(
+                    (-180.0..=180.0).contains(&self.lon),
+                    "lon must be between -180 and 180"
+                );
 
                 let mut map = map.build_static_renderer();
                 if let Some(debug) = self.debug {


### PR DESCRIPTION

Great project — thanks for sharing it!

While trying out the renderer example, I noticed that the x and y parameters only accept positive integer values, which makes it impossible to use latitude and longitude coordinates (f64) which are used by the static image renderer.

This PR would add CLI arguments for --lat, --lon, and --zoom such that the floating-point coordinates can be passed directly to the static image renderer. The tile mode would still use x, y and z.