### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/maplibre/maplibre-native-rs/compare/v0.4.1...v0.4.2) - 2025-10-13
+
+### Other
+
+- *(deps)* bump the all-actions-version-updates group with 2 updates ([#94](https://github.com/maplibre/maplibre-native-rs/pull/94))
+
 ## [0.4.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.4.0...v0.4.1) - 2025-10-06
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.4.1"
+version = "0.4.2"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -74,7 +74,7 @@ futures = "0.3"
 image = "0.25"
 insta = "1.43.2"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.4.1" }
+maplibre_native = { path = ".", version = "0.4.2" }
 tar = "0.4.44"
 thiserror = "2.0.16"
 tokio = { version = "1", features = [], default-features = false }


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.4.1 -> 0.4.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/maplibre/maplibre-native-rs/compare/v0.4.1...v0.4.2) - 2025-10-13

### Other

- *(deps)* bump the all-actions-version-updates group with 2 updates ([#94](https://github.com/maplibre/maplibre-native-rs/pull/94))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).