### PR TITLE
fix: use geographic coordinates in Continuous set_camera

### DIFF
--- a/examples/slint/src/maplibre/headless.rs
+++ b/examples/slint/src/maplibre/headless.rs
@@ -6,6 +6,7 @@ use maplibre_native::MapLoadError;
 use maplibre_native::ResourceOptions;
 use maplibre_native::ScreenCoordinate;
 use maplibre_native::tile_server_options::TileServerOptions;
+use maplibre_native::{Latitude, Longitude};
 use std::cell::RefCell;
 use std::num::NonZeroU32;
 use std::path::Path;
@@ -71,7 +72,7 @@ pub fn create_map(size: Size) -> Rc<RefCell<MapLibre>> {
         .with_pixel_ratio(1.0)
         .with_resource_options(resource_options)
         .build_continuous_renderer();
-    renderer.set_camera(0., 0., 0., 0., 0.); // setting the camera is important, otherwise map libre does nothing (no logs are comming and no map gets generated)
+    renderer.set_camera(Latitude(0.0), Longitude(0.0), 0.0, 0.0, 0.0); // setting the camera is important, otherwise map libre does nothing (no logs are comming and no map gets generated)
     renderer.load_style_from_url(&"https://demotiles.maplibre.org/style.json".parse().unwrap());
 
     let map = Rc::new(RefCell::new(MapLibre::new(renderer)));

--- a/examples/slint/src/maplibre/headless.rs
+++ b/examples/slint/src/maplibre/headless.rs
@@ -71,7 +71,7 @@ pub fn create_map(size: Size) -> Rc<RefCell<MapLibre>> {
         .with_pixel_ratio(1.0)
         .with_resource_options(resource_options)
         .build_continuous_renderer();
-    renderer.set_camera(0, 0, 0, 0., 0.); // setting the camera is important, otherwise map libre does nothing (no logs are comming and no map gets generated)
+    renderer.set_camera(0., 0., 0., 0., 0.); // setting the camera is important, otherwise map libre does nothing (no logs are comming and no map gets generated)
     renderer.load_style_from_url(&"https://demotiles.maplibre.org/style.json".parse().unwrap());
 
     let map = Rc::new(RefCell::new(MapLibre::new(renderer)));

--- a/src/renderer/image_renderer.rs
+++ b/src/renderer/image_renderer.rs
@@ -2,7 +2,7 @@ use super::MapObserver;
 use crate::renderer::bridge::ffi;
 use crate::renderer::bridge::ffi::BridgeImage;
 use crate::renderer::MapDebugOptions;
-use crate::{ScreenCoordinate, Size};
+use crate::{Latitude, Longitude, ScreenCoordinate, Size};
 use cxx::UniquePtr;
 use image::{ImageBuffer, Rgba};
 use std::f64::consts::PI;
@@ -168,7 +168,7 @@ impl ImageRenderer<Tile> {
         }
 
         let (lat, lon) = coords_to_lat_lon(f64::from(zoom), x, y);
-        self.instance.pin_mut().setCamera(lat, lon, f64::from(zoom), 0.0, 0.0);
+        self.instance.pin_mut().setCamera(lat.0, lon.0, f64::from(zoom), 0.0, 0.0);
 
         let data = self.instance.pin_mut().render();
         let bytes = data.as_bytes();
@@ -207,8 +207,15 @@ impl ImageRenderer<Continuous> {
     /// Set the camera position using geographic coordinates.
     ///
     /// Important: Without setting the camera initially no image will be generated!
-    pub fn set_camera(&mut self, lat: f64, lon: f64, zoom: f64, bearing: f64, pitch: f64) {
-        self.instance.pin_mut().setCamera(lat, lon, zoom, bearing, pitch);
+    pub fn set_camera(
+        &mut self,
+        latitude: Latitude,
+        longitude: Longitude,
+        zoom: f64,
+        bearing: f64,
+        pitch: f64,
+    ) {
+        self.instance.pin_mut().setCamera(latitude.0, longitude.0, zoom, bearing, pitch);
     }
 
     /// Get access to the map observer to setup callbacks
@@ -243,12 +250,12 @@ impl ImageRenderer<Continuous> {
 }
 
 #[allow(clippy::cast_precision_loss)]
-fn coords_to_lat_lon(zoom: f64, x: u32, y: u32) -> (f64, f64) {
+fn coords_to_lat_lon(zoom: f64, x: u32, y: u32) -> (Latitude, Longitude) {
     // https://github.com/oldmammuth/slippy_map_tilenames/blob/058678480f4b50b622cda7a48b98647292272346/src/lib.rs#L114
     let zz = 2_f64.powf(zoom);
     let lng = (f64::from(x) + 0.5) / zz * 360_f64 - 180_f64;
     let lat = ((PI * (1_f64 - 2_f64 * (f64::from(y) + 0.5) / zz)).sinh()).atan().to_degrees();
-    (lat, lng)
+    (Latitude(lat), Longitude(lng))
 }
 
 /// Errors that can occur during map rendering operations.
@@ -260,4 +267,25 @@ pub enum RenderingError {
     /// The renderer returned invalid or corrupted image data.
     #[error("Invalid image data received from renderer")]
     InvalidImageData,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{coords_to_lat_lon, Latitude, Longitude};
+
+    #[test]
+    fn converts_tile_zero_to_geographic_center() {
+        let (lat, lon) = coords_to_lat_lon(0.0, 0, 0);
+        assert!(matches!(lat, Latitude(v) if v.abs() < f64::EPSILON));
+        assert!(matches!(lon, Longitude(v) if v.abs() < f64::EPSILON));
+    }
+
+    #[test]
+    fn tile_coordinate_conversion_returns_typed_coordinates() {
+        let (lat, lon) = coords_to_lat_lon(1.0, 1, 1);
+        let Latitude(lat) = lat;
+        let Longitude(lon) = lon;
+        assert!((-90.0..=90.0).contains(&lat));
+        assert!((-180.0..=180.0).contains(&lon));
+    }
 }

--- a/src/renderer/image_renderer.rs
+++ b/src/renderer/image_renderer.rs
@@ -206,6 +206,9 @@ impl ImagePtr {
 impl ImageRenderer<Continuous> {
     /// Set the camera position using geographic coordinates.
     ///
+    /// See [this grapic](https://en.wikipedia.org/wiki/Degrees_of_freedom_(mechanics)#/media/File:Flight_dynamics_with_text.svg)
+    /// as a reminder what bearing, pitch (and yaw) is.
+    ///
     /// Important: Without setting the camera initially no image will be generated!
     pub fn set_camera(
         &mut self,

--- a/src/renderer/image_renderer.rs
+++ b/src/renderer/image_renderer.rs
@@ -204,11 +204,11 @@ impl ImagePtr {
 }
 
 impl ImageRenderer<Continuous> {
-    /// Set the camera
+    /// Set the camera position using geographic coordinates.
+    ///
     /// Important: Without setting the camera initially no image will be generated!
-    pub fn set_camera(&mut self, x: u32, y: u32, zoom: u8, bearing: f64, pitch: f64) {
-        let (lat, lon) = coords_to_lat_lon(f64::from(zoom), x, y);
-        self.instance.pin_mut().setCamera(lat, lon, f64::from(zoom), bearing, pitch);
+    pub fn set_camera(&mut self, lat: f64, lon: f64, zoom: f64, bearing: f64, pitch: f64) {
+        self.instance.pin_mut().setCamera(lat, lon, zoom, bearing, pitch);
     }
 
     /// Get access to the map observer to setup callbacks


### PR DESCRIPTION
## Summary

Fix `ImageRenderer<Continuous>::set_camera` to accept geographic coordinates (lat, lon, zoom as f64) instead of tile coordinates (x, y as u32, zoom as u8).

## Motivation

The underlying C++ FFI function `MapRenderer_setCamera` takes `(lat, lon, zoom, bearing, pitch)` as floating-point values. However, the current Rust `set_camera` accepts tile coordinates `(x: u32, y: u32, zoom: u8)` and converts them internally via `coords_to_lat_lon`.

This creates two problems:

1. **Precision loss**: u32 tile coordinates and u8 zoom cannot represent continuous positions, making smooth camera animations (e.g. fly-to) impossible through this API.
2. **Misleading interface**: callers expect `set_camera` to be a thin wrapper around `MapRenderer_setCamera`, but the implicit coordinate conversion changes the semantics.

The tile coordinate signature was introduced in #115, carried over from the `render_tile` pattern where tile coordinates are the natural input. For `Continuous` mode, geographic coordinates are the correct abstraction.

Since `Continuous` mode has not been included in any release yet, this is not a breaking change to any published API. **I strongly recommend fixing this before the next release ships this API as-is.**

## Changes

- `set_camera(x: u32, y: u32, zoom: u8, bearing: f64, pitch: f64)` -> `set_camera(lat: f64, lon: f64, zoom: f64, bearing: f64, pitch: f64)`
- Remove the `coords_to_lat_lon` conversion (still used by `render_tile`)
- Update the slint example accordingly