### PR TITLE
chore: Add the missing `publish = false` to the slint example.

### DIFF
--- a/examples/slint/Cargo.toml
+++ b/examples/slint/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "slint_map_libre_native"
 version = "0.1.0"
+publish = false
 edition = "2024"
 
 [features]


### PR DESCRIPTION
Prevent release-plz from trying to publish the Slint example and failing.

e.g.) https://github.com/maplibre/maplibre-native-rs/actions/runs/24615720253/job/71978172722