### PR TITLE
chore(ci): Enable macOS Vulkan in the CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,10 @@ jobs:
             backend: metal
             precompiled: 0
             amalgam: 0
-          #- runs-on: macos-latest
-          #  backend: vulkan
-          #  precompiled: 0
-          #  amalgam: 0
+          - runs-on: macos-latest
+            backend: vulkan
+            precompiled: 0
+            amalgam: 0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with: { persist-credentials: false }
@@ -78,6 +78,10 @@ jobs:
         with: { tool: 'just' }
       - run: echo "MLN_PRECOMPILE=${{ matrix.precompiled }}" >> $GITHUB_ENV
       - run: echo "MLN_CORE_LIBRARY_USE_AMALGAM=${{ matrix.amalgam }}" >> $GITHUB_ENV
+      - if: startsWith(matrix.runs-on, 'macos') && matrix.backend == 'vulkan'
+        run: |
+          echo "VK_ICD_FILENAMES=$(brew --prefix molten-vk)/etc/vulkan/icd.d/MoltenVK_icd.json" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=$(brew --prefix vulkan-loader)/lib" >> $GITHUB_ENV
       - run: just env-info install-dependencies '${{ matrix.backend }}'
       - run: rustup update stable && rustup default stable
       - name: Run CI tests (Linux OpenGL via Xvfb)
@@ -115,10 +119,10 @@ jobs:
             backend: metal
             precompiled: 0
             amalgam: 0
-          #- runs-on: macos-latest
-          #  backend: vulkan
-          #  precompiled: 0
-          #  amalgam: 0
+          - runs-on: macos-latest
+            backend: vulkan
+            precompiled: 0
+            amalgam: 0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with: { persist-credentials: false }
@@ -128,6 +132,10 @@ jobs:
         with: { tool: 'just' }
       - run: echo "MLN_PRECOMPILE=${{ matrix.precompiled }}" >> $GITHUB_ENV
       - run: echo "MLN_CORE_LIBRARY_USE_AMALGAM=${{ matrix.amalgam }}" >> $GITHUB_ENV
+      - if: startsWith(matrix.runs-on, 'macos') && matrix.backend == 'vulkan'
+        run: |
+          echo "VK_ICD_FILENAMES=$(brew --prefix molten-vk)/etc/vulkan/icd.d/MoltenVK_icd.json" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=$(brew --prefix vulkan-loader)/lib" >> $GITHUB_ENV
       - run: just env-info install-dependencies '${{ matrix.backend }}'
       - name: Read MSRV
         id: msrv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,11 @@ jobs:
         with: { tool: 'just' }
       - run: echo "MLN_PRECOMPILE=${{ matrix.precompiled }}" >> $GITHUB_ENV
       - run: echo "MLN_CORE_LIBRARY_USE_AMALGAM=${{ matrix.amalgam }}" >> $GITHUB_ENV
+      - run: just env-info install-dependencies '${{ matrix.backend }}'
       - if: startsWith(matrix.runs-on, 'macos') && matrix.backend == 'vulkan'
         run: |
           echo "VK_ICD_FILENAMES=$(brew --prefix molten-vk)/etc/vulkan/icd.d/MoltenVK_icd.json" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=$(brew --prefix vulkan-loader)/lib" >> $GITHUB_ENV
-      - run: just env-info install-dependencies '${{ matrix.backend }}'
       - run: rustup update stable && rustup default stable
       - name: Run CI tests (Linux OpenGL via Xvfb)
         if: startsWith(matrix.runs-on, 'ubuntu') && matrix.backend == 'opengl'
@@ -132,11 +132,11 @@ jobs:
         with: { tool: 'just' }
       - run: echo "MLN_PRECOMPILE=${{ matrix.precompiled }}" >> $GITHUB_ENV
       - run: echo "MLN_CORE_LIBRARY_USE_AMALGAM=${{ matrix.amalgam }}" >> $GITHUB_ENV
+      - run: just env-info install-dependencies '${{ matrix.backend }}'
       - if: startsWith(matrix.runs-on, 'macos') && matrix.backend == 'vulkan'
         run: |
           echo "VK_ICD_FILENAMES=$(brew --prefix molten-vk)/etc/vulkan/icd.d/MoltenVK_icd.json" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=$(brew --prefix vulkan-loader)/lib" >> $GITHUB_ENV
-      - run: just env-info install-dependencies '${{ matrix.backend }}'
       - name: Read MSRV
         id: msrv
         run: echo "value=$(just get-msrv)" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following platform and rendering-API combinations are supported and tested i
 ❌ = Not possible
 </sub>
 
-[^1]: Vulcan support on macos is provided via `MoltenVK`. There is a slight performance overhead for this with little upsides. Both Metal and Vulcan run through the same extensive test suite upstream. You can use Vulcan if you find a bug in the Metal implementation until we have fixed it upstream.
+[^1]: Vulkan support on macos is provided via `MoltenVK`. There is a slight performance overhead for this with little upsides. Both Metal and Vulkan run through the same extensive test suite upstream. You can use Vulkan if you find a bug in the Metal implementation until we have fixed it upstream.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The following platform and rendering-API combinations are supported and tested i
 | Linux ARM   | ❌    | ✅     | ✅     |
 | Windows x86 | ❌    | 🟨     | 🟨     |
 | Windows ARM | ❌    | 🟨     | 🟨     |
-| macOS ARM   | ✅    | 🟨[^1] | ❌     |
+| macOS ARM   | ✅    | ✅[^1] | ❌     |
 
 <sub>
 ✅ = IS supported and tested in CI


### PR DESCRIPTION
Follow-up to #152: enable macOS Vulkan in CI alongside macOS Metal.