### PR TITLE
feat(renderer): add Rust FileSource callback bridge

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,8 @@ const BRIDGE_FILES: &[&str] = &[
     "src/cpp/map_renderer.h",
     "src/cpp/renderer_observer.h",
     "src/cpp/map_observer.h",
+    "src/cpp/rust_file_source.h",
+    "src/cpp/rust_file_source.cpp",
     "src/cpp/rust_log_observer.h",
     "src/cpp/sources/sources.h",
     "src/cpp/sources/sources.cpp",

--- a/src/cpp/rust_file_source.cpp
+++ b/src/cpp/rust_file_source.cpp
@@ -44,10 +44,8 @@ public:
         // deadlock the `frontend->render` call waiting for its own tile.
         // Sync dispatch is safe because Rust-backed sources (mbtiles SQLite,
         // filesystem read) don't block long enough to matter, matching mbgl's
-        // in-memory test doubles.
-        mbgl::Log::Debug(mbgl::Event::General,
-                         "rust-fs request kind=" + std::to_string(static_cast<unsigned>(resource.kind))
-                         + " url=" + resource.url);
+        // in-memory test doubles. Per-request tracing happens on the Rust
+        // side in `fs_request_callback`.
         cb(invokeCallback(resource));
         return std::make_unique<NoopAsyncRequest>();
     }

--- a/src/cpp/rust_file_source.cpp
+++ b/src/cpp/rust_file_source.cpp
@@ -80,10 +80,13 @@ private:
         }
 
         response.noContent = rr.no_content;
-        if (!rr.no_content && !rr.data.empty()) {
-            // The Rust `Vec<u8>` was moved across the cxx boundary (no copy);
-            // this is the one unavoidable copy — mbgl insists on
-            // `shared_ptr<const std::string>`.
+        if (!rr.no_content) {
+            // Always materialise `data` for non-NoContent successes, even
+            // when zero-length: a default-constructed `shared_ptr` reads as
+            // "no data set" downstream and is indistinguishable from a
+            // failed response. The Rust `Vec<u8>` was moved across the cxx
+            // boundary (no copy); the std::string construction is the one
+            // unavoidable copy — mbgl insists on `shared_ptr<const std::string>`.
             response.data = std::make_shared<std::string>(
                 reinterpret_cast<const char*>(rr.data.data()),
                 rr.data.size());

--- a/src/cpp/rust_file_source.cpp
+++ b/src/cpp/rust_file_source.cpp
@@ -19,28 +19,6 @@ namespace bridge {
 
 namespace {
 
-// Compile-time cross-checks: the Rust-side `ResourceKind` and `FsErrorReason`
-// enums duplicate mbgl discriminants over the cxx boundary as raw u8. Pin
-// each discriminant so an upstream mbgl reorder fails the build instead of
-// silently mapping tile requests to spritejson requests.
-static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::Unknown)      == 0, "ResourceKind::Unknown discriminant drift");
-static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::Style)        == 1, "ResourceKind::Style discriminant drift");
-static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::Source)       == 2, "ResourceKind::Source discriminant drift");
-static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::Tile)         == 3, "ResourceKind::Tile discriminant drift");
-static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::Glyphs)       == 4, "ResourceKind::Glyphs discriminant drift");
-static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::SpriteImage)  == 5, "ResourceKind::SpriteImage discriminant drift");
-static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::SpriteJSON)   == 6, "ResourceKind::SpriteJSON discriminant drift");
-static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::Image)        == 7, "ResourceKind::Image discriminant drift");
-
-// RustFsResponse uses `0` as the no-error sentinel. Verify mbgl's Reason
-// enum never produces `0`, and pin the reason discriminants we map onto.
-static_assert(static_cast<uint8_t>(mbgl::Response::Error::Reason::Success)    != 0, "FsErrorReason sentinel 0 collides with Success");
-static_assert(static_cast<uint8_t>(mbgl::Response::Error::Reason::NotFound)   == 2, "FsErrorReason::NotFound discriminant drift");
-static_assert(static_cast<uint8_t>(mbgl::Response::Error::Reason::Server)     == 3, "FsErrorReason::Server discriminant drift");
-static_assert(static_cast<uint8_t>(mbgl::Response::Error::Reason::Connection) == 4, "FsErrorReason::Connection discriminant drift");
-static_assert(static_cast<uint8_t>(mbgl::Response::Error::Reason::RateLimit)  == 5, "FsErrorReason::RateLimit discriminant drift");
-static_assert(static_cast<uint8_t>(mbgl::Response::Error::Reason::Other)      == 6, "FsErrorReason::Other discriminant drift");
-
 // AsyncRequest subclass whose destructor cancels. Our dispatch is synchronous
 // so by the time this handle reaches the caller the callback has already
 // fired — cancellation is a structural no-op.
@@ -93,13 +71,12 @@ public:
 private:
     mbgl::Response invokeCallback(const mbgl::Resource& resource) {
         const rust::Str url(resource.url.data(), resource.url.size());
-        RustFsResponse rr = fs_request_callback(**callback_, url,
-                                                static_cast<uint8_t>(resource.kind));
+        RustFsResponse rr = fs_request_callback(**callback_, url, resource.kind);
 
         mbgl::Response response;
-        if (rr.error_reason != 0) {
+        if (rr.error_reason != FsErrorReason::Success) {
             response.error = std::make_unique<mbgl::Response::Error>(
-                static_cast<mbgl::Response::Error::Reason>(rr.error_reason),
+                rr.error_reason,
                 std::string(rr.error_message.data(), rr.error_message.size()));
             return response;
         }

--- a/src/cpp/rust_file_source.cpp
+++ b/src/cpp/rust_file_source.cpp
@@ -1,0 +1,137 @@
+#include "rust_file_source.h"
+#include "maplibre_native/src/renderer/bridge.rs.h"
+
+#include <mbgl/storage/file_source.hpp>
+#include <mbgl/storage/file_source_manager.hpp>
+#include <mbgl/storage/resource.hpp>
+#include <mbgl/storage/resource_options.hpp>
+#include <mbgl/storage/response.hpp>
+#include <mbgl/util/async_request.hpp>
+#include <mbgl/util/client_options.hpp>
+#include <mbgl/util/logging.hpp>
+
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace mln {
+namespace bridge {
+
+namespace {
+
+// Compile-time cross-checks: the Rust-side `ResourceKind` and `FsErrorReason`
+// enums duplicate mbgl discriminants over the cxx boundary as raw u8. Pin
+// each discriminant so an upstream mbgl reorder fails the build instead of
+// silently mapping tile requests to spritejson requests.
+static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::Unknown)      == 0, "ResourceKind::Unknown discriminant drift");
+static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::Style)        == 1, "ResourceKind::Style discriminant drift");
+static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::Source)       == 2, "ResourceKind::Source discriminant drift");
+static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::Tile)         == 3, "ResourceKind::Tile discriminant drift");
+static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::Glyphs)       == 4, "ResourceKind::Glyphs discriminant drift");
+static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::SpriteImage)  == 5, "ResourceKind::SpriteImage discriminant drift");
+static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::SpriteJSON)   == 6, "ResourceKind::SpriteJSON discriminant drift");
+static_assert(static_cast<uint8_t>(mbgl::Resource::Kind::Image)        == 7, "ResourceKind::Image discriminant drift");
+
+// RustFsResponse uses `0` as the no-error sentinel. Verify mbgl's Reason
+// enum never produces `0`, and pin the reason discriminants we map onto.
+static_assert(static_cast<uint8_t>(mbgl::Response::Error::Reason::Success)    != 0, "FsErrorReason sentinel 0 collides with Success");
+static_assert(static_cast<uint8_t>(mbgl::Response::Error::Reason::NotFound)   == 2, "FsErrorReason::NotFound discriminant drift");
+static_assert(static_cast<uint8_t>(mbgl::Response::Error::Reason::Server)     == 3, "FsErrorReason::Server discriminant drift");
+static_assert(static_cast<uint8_t>(mbgl::Response::Error::Reason::Connection) == 4, "FsErrorReason::Connection discriminant drift");
+static_assert(static_cast<uint8_t>(mbgl::Response::Error::Reason::RateLimit)  == 5, "FsErrorReason::RateLimit discriminant drift");
+static_assert(static_cast<uint8_t>(mbgl::Response::Error::Reason::Other)      == 6, "FsErrorReason::Other discriminant drift");
+
+// AsyncRequest subclass whose destructor cancels. Our dispatch is synchronous
+// so by the time this handle reaches the caller the callback has already
+// fired — cancellation is a structural no-op.
+class NoopAsyncRequest final : public mbgl::AsyncRequest {
+public:
+    NoopAsyncRequest() = default;
+    ~NoopAsyncRequest() override = default;
+};
+
+class RustFileSource final : public mbgl::FileSource {
+public:
+    RustFileSource(std::shared_ptr<rust::Box<FileSourceRequestCallback>> callback,
+                   mbgl::ResourceOptions resourceOpts,
+                   mbgl::ClientOptions clientOpts)
+        : callback_(std::move(callback)),
+          resourceOpts_(std::move(resourceOpts)),
+          clientOpts_(std::move(clientOpts)) {}
+
+    std::unique_ptr<mbgl::AsyncRequest> request(const mbgl::Resource& resource,
+                                                Callback cb) override {
+        // Static-render mode has no pumped run loop on the render thread, so
+        // posting the callback via `RunLoop::Get()->invokeCancellable` would
+        // deadlock the `frontend->render` call waiting for its own tile.
+        // Sync dispatch is safe because Rust-backed sources (mbtiles SQLite,
+        // filesystem read) don't block long enough to matter, matching mbgl's
+        // in-memory test doubles.
+        mbgl::Log::Debug(mbgl::Event::General,
+                         "rust-fs request kind=" + std::to_string(static_cast<unsigned>(resource.kind))
+                         + " url=" + resource.url);
+        cb(invokeCallback(resource));
+        return std::make_unique<NoopAsyncRequest>();
+    }
+
+    bool canRequest(const mbgl::Resource&) const override { return true; }
+
+    void setResourceOptions(mbgl::ResourceOptions options) override {
+        resourceOpts_ = std::move(options);
+    }
+    mbgl::ResourceOptions getResourceOptions() override {
+        return resourceOpts_.clone();
+    }
+
+    void setClientOptions(mbgl::ClientOptions options) override {
+        clientOpts_ = std::move(options);
+    }
+    mbgl::ClientOptions getClientOptions() override {
+        return clientOpts_.clone();
+    }
+
+private:
+    mbgl::Response invokeCallback(const mbgl::Resource& resource) {
+        const rust::Str url(resource.url.data(), resource.url.size());
+        RustFsResponse rr = fs_request_callback(**callback_, url,
+                                                static_cast<uint8_t>(resource.kind));
+
+        mbgl::Response response;
+        if (rr.error_reason != 0) {
+            response.error = std::make_unique<mbgl::Response::Error>(
+                static_cast<mbgl::Response::Error::Reason>(rr.error_reason),
+                std::string(rr.error_message.data(), rr.error_message.size()));
+            return response;
+        }
+
+        response.noContent = rr.no_content;
+        if (!rr.no_content && !rr.data.empty()) {
+            // The Rust `Vec<u8>` was moved across the cxx boundary (no copy);
+            // this is the one unavoidable copy — mbgl insists on
+            // `shared_ptr<const std::string>`.
+            response.data = std::make_shared<std::string>(
+                reinterpret_cast<const char*>(rr.data.data()),
+                rr.data.size());
+        }
+        return response;
+    }
+
+    std::shared_ptr<rust::Box<FileSourceRequestCallback>> callback_;
+    mbgl::ResourceOptions resourceOpts_;
+    mbgl::ClientOptions clientOpts_;
+};
+
+} // namespace
+
+void register_rust_file_source_factory(rust::Box<FileSourceRequestCallback> callback) {
+    auto shared_callback = std::make_shared<rust::Box<FileSourceRequestCallback>>(std::move(callback));
+    mbgl::FileSourceManager::get()->registerFileSourceFactory(
+        mbgl::FileSourceType::ResourceLoader,
+        [shared_callback](const mbgl::ResourceOptions& ro, const mbgl::ClientOptions& co)
+            -> std::unique_ptr<mbgl::FileSource> {
+            return std::make_unique<RustFileSource>(shared_callback, ro.clone(), co.clone());
+        });
+}
+
+} // namespace bridge
+} // namespace mln

--- a/src/cpp/rust_file_source.h
+++ b/src/cpp/rust_file_source.h
@@ -16,9 +16,20 @@
 // owning Map is destroyed.
 
 #include "rust/cxx.h"
+#include <mbgl/storage/resource.hpp>
+#include <mbgl/storage/response.hpp>
 
 namespace mln {
 namespace bridge {
+
+// cxx doesn't support nested enums directly, so flatten mbgl's
+// `Resource::Kind` and `Response::Error::Reason` into top-level aliases
+// the cxx::bridge can pick up. Same pattern as `MapObserverCameraChangeMode`
+// in src/cpp/map_observer.h. Names + discriminants must stay aligned with
+// the Rust-side enum declarations in src/renderer/bridge.rs; cxx codegen
+// validates the match at compile time.
+using ResourceKind = mbgl::Resource::Kind;
+using FsErrorReason = mbgl::Response::Error::Reason;
 
 // Opaque Rust type — defined in src/renderer/file_source.rs.
 struct FileSourceRequestCallback;

--- a/src/cpp/rust_file_source.h
+++ b/src/cpp/rust_file_source.h
@@ -11,9 +11,17 @@
 //
 // Factory registration is process-global (mbgl::FileSourceManager is a
 // singleton). Call `register_rust_file_source_factory` once before any
-// `mbgl::Map` is constructed. A subsequent call replaces the previous
-// callback but leaves existing RustFileSource instances alive until their
-// owning Map is destroyed.
+// `mbgl::Map` is constructed.
+//
+// `FileSourceManager` *also* caches FileSource instances by `(type,
+// ResourceOptions)`; `registerFileSourceFactory` only swaps the factory
+// slot and never evicts the cache. A subsequent call therefore takes
+// effect only for `Map`s constructed with `ResourceOptions` that don't
+// already have a live cached FileSource — in practice, only after every
+// previously built renderer has been dropped, or by varying
+// `ResourceOptions` (e.g. a unique `platformContext`) per renderer. Two
+// concurrent renderers with different callbacks are not supported by
+// this layer.
 
 #include "rust/cxx.h"
 #include <mbgl/storage/resource.hpp>

--- a/src/cpp/rust_file_source.h
+++ b/src/cpp/rust_file_source.h
@@ -1,0 +1,30 @@
+#pragma once
+
+// Rust-backed FileSource bridge.
+//
+// Installs an `mbgl::FileSource` factory for `FileSourceType::ResourceLoader`
+// that delegates every resource request to a Rust closure. This replaces the
+// default ResourceLoader (which composes Asset/Database/Network/Mbtiles/Pmtiles
+// sources) with a single Rust-supplied handler — letting callers serve
+// mbtiles://, file://, and custom schemes from Rust without running a sidecar
+// HTTP server or pre-extracting tiles.
+//
+// Factory registration is process-global (mbgl::FileSourceManager is a
+// singleton). Call `register_rust_file_source_factory` once before any
+// `mbgl::Map` is constructed. A subsequent call replaces the previous
+// callback but leaves existing RustFileSource instances alive until their
+// owning Map is destroyed.
+
+#include "rust/cxx.h"
+
+namespace mln {
+namespace bridge {
+
+// Opaque Rust type — defined in src/renderer/file_source.rs.
+struct FileSourceRequestCallback;
+
+// Implementation in rust_file_source.cpp.
+void register_rust_file_source_factory(rust::Box<FileSourceRequestCallback> callback);
+
+} // namespace bridge
+} // namespace mln

--- a/src/renderer/bridge.rs
+++ b/src/renderer/bridge.rs
@@ -411,14 +411,57 @@ pub mod map_observer {
 /// Rust-backed FileSource bridge. See `src/cpp/rust_file_source.{h,cpp}`
 /// for the C++ side.
 pub mod file_source {
-    /// FFI shape for a resource-request response. `error_reason == 0`
-    /// means success; non-zero values map directly onto
-    /// `mbgl::Response::Error::Reason`. `no_content == true` with
-    /// `error_reason == 0` is a well-formed miss (e.g. tile not present).
+    #[namespace = "mln::bridge"]
+    #[repr(u8)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// Resource kinds — mirror of `mbgl::Resource::Kind`.
+    pub enum ResourceKind {
+        /// Unknown / unspecified resource kind.
+        Unknown = 0,
+        /// A style.json.
+        Style = 1,
+        /// A TileJSON / source descriptor.
+        Source = 2,
+        /// A single tile (vector or raster).
+        Tile = 3,
+        /// A glyph PBF range.
+        Glyphs = 4,
+        /// A sprite sheet PNG.
+        SpriteImage = 5,
+        /// A sprite sheet JSON.
+        SpriteJSON = 6,
+        /// A generic image resource.
+        Image = 7,
+    }
+
+    #[namespace = "mln::bridge"]
+    #[repr(u8)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// Error reason categories — mirror of `mbgl::Response::Error::Reason`.
+    pub enum FsErrorReason {
+        /// mbgl's "no error" sentinel; not a meaningful error category.
+        Success = 1,
+        /// Resource not found at the requested URL.
+        NotFound = 2,
+        /// Server-side error (5xx and similar).
+        Server = 3,
+        /// Transport-level connection failure.
+        Connection = 4,
+        /// Rate-limit response.
+        RateLimit = 5,
+        /// Any other error.
+        Other = 6,
+    }
+
+    /// FFI shape for a resource-request response. `error_reason ==
+    /// FsErrorReason::Success` means no error; any other value is the
+    /// mbgl reason that gets attached to the `mbgl::Response::Error`.
+    /// `no_content == true` with `error_reason == Success` is a
+    /// well-formed miss (e.g. tile not present).
     #[derive(Debug)]
     pub struct RustFsResponse {
         pub data: Vec<u8>,
-        pub error_reason: u8,
+        pub error_reason: FsErrorReason,
         pub error_message: String,
         pub no_content: bool,
     }
@@ -429,12 +472,14 @@ pub mod file_source {
         fn fs_request_callback(
             callback: &FileSourceRequestCallback,
             url: &str,
-            kind: u8,
+            kind: ResourceKind,
         ) -> RustFsResponse;
     }
 
     unsafe extern "C++" {
         include!("rust_file_source.h");
+        type ResourceKind;
+        type FsErrorReason;
 
         /// Install the Rust closure as the `ResourceLoader` file source
         /// factory. Process-global; replaces any previous callback.

--- a/src/renderer/bridge.rs
+++ b/src/renderer/bridge.rs
@@ -3,6 +3,7 @@ use crate::renderer::callbacks::{
     void_callback, CameraDidChangeCallback, FailingLoadingMapCallback,
     FinishRenderingFrameCallback, VoidCallback,
 };
+use crate::renderer::file_source::{fs_request_callback, FileSourceRequestCallback};
 use std::fmt::Display;
 use std::ops::Sub;
 
@@ -402,6 +403,42 @@ pub mod map_observer {
             self: &CxxMapObserver,
             callback: Box<CameraDidChangeCallback>,
         );
+    }
+}
+
+#[allow(clippy::borrow_as_ptr, unused_qualifications)]
+#[cxx::bridge(namespace = "mln::bridge")]
+/// Rust-backed FileSource bridge. See `src/cpp/rust_file_source.{h,cpp}`
+/// for the C++ side.
+pub mod file_source {
+    /// FFI shape for a resource-request response. `error_reason == 0`
+    /// means success; non-zero values map directly onto
+    /// `mbgl::Response::Error::Reason`. `no_content == true` with
+    /// `error_reason == 0` is a well-formed miss (e.g. tile not present).
+    #[derive(Debug)]
+    pub struct RustFsResponse {
+        pub data: Vec<u8>,
+        pub error_reason: u8,
+        pub error_message: String,
+        pub no_content: bool,
+    }
+
+    extern "Rust" {
+        type FileSourceRequestCallback;
+
+        fn fs_request_callback(
+            callback: &FileSourceRequestCallback,
+            url: &str,
+            kind: u8,
+        ) -> RustFsResponse;
+    }
+
+    unsafe extern "C++" {
+        include!("rust_file_source.h");
+
+        /// Install the Rust closure as the `ResourceLoader` file source
+        /// factory. Process-global; replaces any previous callback.
+        fn register_rust_file_source_factory(callback: Box<FileSourceRequestCallback>);
     }
 }
 

--- a/src/renderer/builder.rs
+++ b/src/renderer/builder.rs
@@ -33,9 +33,9 @@ pub struct ImageRendererBuilder {
 
     resource_options: Option<ResourceOptions>,
 
-    /// Optional Rust-supplied FileSource callback. When set, installs a
+    /// Optional Rust-supplied `FileSource` callback. When set, installs a
     /// process-global factory at build time that delegates every resource
-    /// request to this closure, bypassing the mbgl default ResourceLoader.
+    /// request to this closure, bypassing the mbgl default `ResourceLoader`.
     file_source_callback: Option<FileSourceRequestCallback>,
 }
 
@@ -88,11 +88,11 @@ impl ImageRendererBuilder {
         self
     }
 
-    /// Install a Rust closure as the FileSource callback.
+    /// Install a Rust closure as the `FileSource` callback.
     ///
     /// The closure is invoked for every resource mbgl needs to render the
     /// style (tiles, glyphs, sprites, etc.). It replaces the mbgl default
-    /// ResourceLoader entirely, so the closure must handle every URL
+    /// `ResourceLoader` entirely, so the closure must handle every URL
     /// scheme referenced by the style — typical schemes are `mbtiles://`,
     /// `file://`, and any custom ones the caller needs.
     ///

--- a/src/renderer/builder.rs
+++ b/src/renderer/builder.rs
@@ -1,9 +1,6 @@
 //! Image renderer configuration and builder
 
 use crate::renderer::bridge::ffi;
-use crate::renderer::bridge::file_source::register_rust_file_source_factory;
-use crate::renderer::bridge::file_source::ResourceKind;
-use crate::renderer::file_source::{FileSourceRequestCallback, FsResponse};
 use crate::renderer::{Continuous, ImageRenderer, MapMode, Static, Tile};
 use crate::ResourceOptions;
 use std::marker::PhantomData;
@@ -32,11 +29,6 @@ pub struct ImageRendererBuilder {
     pixel_ratio: f32,
 
     resource_options: Option<ResourceOptions>,
-
-    /// Optional Rust-supplied `FileSource` callback. When set, installs a
-    /// process-global factory at build time that delegates every resource
-    /// request to this closure, bypassing the mbgl default `ResourceLoader`.
-    file_source_callback: Option<FileSourceRequestCallback>,
 }
 
 impl Default for ImageRendererBuilder {
@@ -47,7 +39,6 @@ impl Default for ImageRendererBuilder {
             height: NonZeroU32::new(512).unwrap(),
             pixel_ratio: 1.0,
             resource_options: None,
-            file_source_callback: None,
         }
     }
 }
@@ -88,34 +79,6 @@ impl ImageRendererBuilder {
         self
     }
 
-    /// Install a Rust closure as the `FileSource` callback.
-    ///
-    /// The closure is invoked for every resource mbgl needs to render the
-    /// style (tiles, glyphs, sprites, etc.). It replaces the mbgl default
-    /// `ResourceLoader` entirely, so the closure must handle every URL
-    /// scheme referenced by the style — typical schemes are `mbtiles://`,
-    /// `file://`, and any custom ones the caller needs.
-    ///
-    /// Registration is **process-global**: `mbgl::FileSourceManager` is a
-    /// singleton, so a later call to `build_*_renderer` replaces the
-    /// factory for all *future* `ImageRenderer` instances. Existing
-    /// renderers keep their original callback because mbgl captured their
-    /// `FileSource` at `Map`-construction time. In practice, running two
-    /// renderers in one process with *different* callbacks is unsupported
-    /// — use one process per callback.
-    ///
-    /// `Send + Sync` are required because mbgl may invoke the same
-    /// captured callback from multiple renderers on independent threads;
-    /// the closure must be safe for concurrent use.
-    #[must_use]
-    pub fn with_file_source_callback<F>(mut self, callback: F) -> Self
-    where
-        F: Fn(&str, ResourceKind) -> FsResponse + Send + Sync + 'static,
-    {
-        self.file_source_callback = Some(FileSourceRequestCallback::new(callback));
-        self
-    }
-
     /// Builds a static image renderer
     #[must_use]
     pub fn build_static_renderer(self) -> ImageRenderer<Static> {
@@ -141,13 +104,6 @@ impl ImageRendererBuilder {
 impl<S> ImageRenderer<S> {
     /// Creates a new renderer instance
     fn new(map_mode: MapMode, opts: ImageRendererBuilder) -> Self {
-        // Install the FileSource callback BEFORE constructing the C++
-        // renderer: mbgl::Map resolves its FileSource during construction,
-        // so the factory has to be in place by then.
-        if let Some(callback) = opts.file_source_callback {
-            register_rust_file_source_factory(Box::new(callback));
-        }
-
         let resource_options = opts.resource_options.unwrap_or_default();
         let map = ffi::MapRenderer_new(
             map_mode,

--- a/src/renderer/builder.rs
+++ b/src/renderer/builder.rs
@@ -2,7 +2,8 @@
 
 use crate::renderer::bridge::ffi;
 use crate::renderer::bridge::file_source::register_rust_file_source_factory;
-use crate::renderer::file_source::{FileSourceRequestCallback, FsResponse, ResourceKind};
+use crate::renderer::bridge::file_source::ResourceKind;
+use crate::renderer::file_source::{FileSourceRequestCallback, FsResponse};
 use crate::renderer::{Continuous, ImageRenderer, MapMode, Static, Tile};
 use crate::ResourceOptions;
 use std::marker::PhantomData;

--- a/src/renderer/builder.rs
+++ b/src/renderer/builder.rs
@@ -1,6 +1,8 @@
 //! Image renderer configuration and builder
 
 use crate::renderer::bridge::ffi;
+use crate::renderer::bridge::file_source::register_rust_file_source_factory;
+use crate::renderer::file_source::{FileSourceRequestCallback, FsResponse, ResourceKind};
 use crate::renderer::{Continuous, ImageRenderer, MapMode, Static, Tile};
 use crate::ResourceOptions;
 use std::marker::PhantomData;
@@ -29,6 +31,11 @@ pub struct ImageRendererBuilder {
     pixel_ratio: f32,
 
     resource_options: Option<ResourceOptions>,
+
+    /// Optional Rust-supplied FileSource callback. When set, installs a
+    /// process-global factory at build time that delegates every resource
+    /// request to this closure, bypassing the mbgl default ResourceLoader.
+    file_source_callback: Option<FileSourceRequestCallback>,
 }
 
 impl Default for ImageRendererBuilder {
@@ -39,6 +46,7 @@ impl Default for ImageRendererBuilder {
             height: NonZeroU32::new(512).unwrap(),
             pixel_ratio: 1.0,
             resource_options: None,
+            file_source_callback: None,
         }
     }
 }
@@ -79,6 +87,34 @@ impl ImageRendererBuilder {
         self
     }
 
+    /// Install a Rust closure as the FileSource callback.
+    ///
+    /// The closure is invoked for every resource mbgl needs to render the
+    /// style (tiles, glyphs, sprites, etc.). It replaces the mbgl default
+    /// ResourceLoader entirely, so the closure must handle every URL
+    /// scheme referenced by the style — typical schemes are `mbtiles://`,
+    /// `file://`, and any custom ones the caller needs.
+    ///
+    /// Registration is **process-global**: `mbgl::FileSourceManager` is a
+    /// singleton, so a later call to `build_*_renderer` replaces the
+    /// factory for all *future* `ImageRenderer` instances. Existing
+    /// renderers keep their original callback because mbgl captured their
+    /// `FileSource` at `Map`-construction time. In practice, running two
+    /// renderers in one process with *different* callbacks is unsupported
+    /// — use one process per callback.
+    ///
+    /// `Send + Sync` are required because mbgl may invoke the same
+    /// captured callback from multiple renderers on independent threads;
+    /// the closure must be safe for concurrent use.
+    #[must_use]
+    pub fn with_file_source_callback<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(&str, ResourceKind) -> FsResponse + Send + Sync + 'static,
+    {
+        self.file_source_callback = Some(FileSourceRequestCallback::new(callback));
+        self
+    }
+
     /// Builds a static image renderer
     #[must_use]
     pub fn build_static_renderer(self) -> ImageRenderer<Static> {
@@ -104,6 +140,13 @@ impl ImageRendererBuilder {
 impl<S> ImageRenderer<S> {
     /// Creates a new renderer instance
     fn new(map_mode: MapMode, opts: ImageRendererBuilder) -> Self {
+        // Install the FileSource callback BEFORE constructing the C++
+        // renderer: mbgl::Map resolves its FileSource during construction,
+        // so the factory has to be in place by then.
+        if let Some(callback) = opts.file_source_callback {
+            register_rust_file_source_factory(Box::new(callback));
+        }
+
         let resource_options = opts.resource_options.unwrap_or_default();
         let map = ffi::MapRenderer_new(
             map_mode,

--- a/src/renderer/callbacks.rs
+++ b/src/renderer/callbacks.rs
@@ -5,12 +5,18 @@ use crate::renderer::bridge::map_observer::MapObserverCameraChangeMode;
 use std::fmt::Debug;
 
 macro_rules! callback {
+    // Simple callback without extra trait bounds.
     ($callback_name:ident, $callback_f:path) => {
+        callback!($callback_name, $callback_f,);
+    };
+    // Callback with extra trait bounds, e.g.
+    //     callback!(Cb, Fn(&str) -> Response, Send, Sync);
+    ($callback_name:ident, $callback_f:path, $($bound:path),*) => {
         /// Callback object
-        pub struct $callback_name(Box<dyn $callback_f + 'static>);
+        pub struct $callback_name(pub(crate) Box<dyn $callback_f + 'static $(+ $bound)*>);
         impl $callback_name {
             /// Create a new callback object
-            pub fn new<F: $callback_f + 'static>(callback: F) -> Self {
+            pub fn new<F: $callback_f + 'static $(+ $bound)*>(callback: F) -> Self {
                 Self(Box::new(callback))
             }
         }
@@ -22,6 +28,7 @@ macro_rules! callback {
         }
     };
 }
+pub(crate) use callback;
 
 callback!(VoidCallback, Fn());
 /// General callback with any argument

--- a/src/renderer/file_source.rs
+++ b/src/renderer/file_source.rs
@@ -1,0 +1,130 @@
+//! Rust-supplied FileSource callback.
+//!
+//! Pair with the C++ side defined in `src/cpp/rust_file_source.{h,cpp}`. The
+//! Rust closure handed to
+//! [`ImageRendererBuilder::with_file_source_callback`](crate::ImageRendererBuilder::with_file_source_callback)
+//! serves every resource mbgl asks for — styles, tilesets, tiles, glyphs,
+//! sprites, images. The URL scheme is not filtered on the C++ side, so the
+//! callback owns scheme dispatch (e.g. `mbtiles://`, `file://`, custom).
+
+use std::fmt::Debug;
+
+use crate::renderer::callbacks::callback;
+
+/// Kind of resource being requested. Mirrors `mbgl::Resource::Kind` from
+/// `mbgl/storage/resource.hpp`; discriminant values are pinned byte-for-byte
+/// to that enum by `static_assert`s in `rust_file_source.cpp`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ResourceKind {
+    /// Unknown / unspecified resource kind.
+    Unknown = 0,
+    /// A style.json.
+    Style = 1,
+    /// A TileJSON / source descriptor.
+    Source = 2,
+    /// A single tile (vector or raster).
+    Tile = 3,
+    /// A glyph PBF range.
+    Glyphs = 4,
+    /// A sprite sheet PNG.
+    SpriteImage = 5,
+    /// A sprite sheet JSON.
+    SpriteJSON = 6,
+    /// A generic image resource.
+    Image = 7,
+}
+
+impl ResourceKind {
+    fn from_u8(v: u8) -> Self {
+        match v {
+            1 => Self::Style,
+            2 => Self::Source,
+            3 => Self::Tile,
+            4 => Self::Glyphs,
+            5 => Self::SpriteImage,
+            6 => Self::SpriteJSON,
+            7 => Self::Image,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// Error reason for a failed resource request. Mirrors
+/// `mbgl::Response::Error::Reason`; discriminant values are pinned to that
+/// enum by `static_assert`s in `rust_file_source.cpp`. The `0` discriminant
+/// is intentionally reserved on the FFI side to mean "no error" —
+/// `mbgl::Response::Error::Reason` starts at `Success = 1`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FsErrorReason {
+    /// Resource not found at the requested URL.
+    NotFound = 2,
+    /// Server-side error (5xx, etc.).
+    Server = 3,
+    /// Transport-level connection failure.
+    Connection = 4,
+    /// Rate-limit response.
+    RateLimit = 5,
+    /// Any other error.
+    Other = 6,
+}
+
+/// Return value for a resource request callback.
+#[derive(Debug)]
+pub enum FsResponse {
+    /// Request succeeded; bytes are the raw resource body.
+    Ok(Vec<u8>),
+    /// Request was a well-formed miss (e.g. mbtiles tile not present at
+    /// this z/x/y). mbgl treats this as a 204-equivalent — no error, no
+    /// body. Overzoomed tiles should use this rather than [`FsResponse::Error`].
+    NoContent,
+    /// Request failed. The reason maps directly to the mbgl error enum so
+    /// mbgl-internal retry/backoff logic still applies.
+    Error {
+        /// Category of failure.
+        reason: FsErrorReason,
+        /// Human-readable message for logging.
+        message: String,
+    },
+}
+
+// Send + Sync are load-bearing: `mbgl::FileSourceManager` is a singleton, so
+// the same callback is captured by every `RustFileSource` instance that the
+// factory produces. If a consumer constructs more than one `ImageRenderer`
+// (or mbgl ever spawns a second file-source-owning thread upstream), the
+// callback will be invoked from multiple threads and must be thread-safe.
+callback!(FileSourceRequestCallback,
+          Fn(&str, ResourceKind) -> FsResponse,
+          Send, Sync);
+
+/// Bridge function invoked by C++ for every resource request. Not called
+/// directly from user code — exposed via the cxx bridge in
+/// `src/renderer/bridge.rs`.
+pub(crate) fn fs_request_callback(
+    callback: &FileSourceRequestCallback,
+    url: &str,
+    kind: u8,
+) -> crate::renderer::bridge::file_source::RustFsResponse {
+    use crate::renderer::bridge::file_source::RustFsResponse;
+    match (callback.0)(url, ResourceKind::from_u8(kind)) {
+        FsResponse::Ok(bytes) => RustFsResponse {
+            data: bytes,
+            error_reason: 0,
+            error_message: String::new(),
+            no_content: false,
+        },
+        FsResponse::NoContent => RustFsResponse {
+            data: Vec::new(),
+            error_reason: 0,
+            error_message: String::new(),
+            no_content: true,
+        },
+        FsResponse::Error { reason, message } => RustFsResponse {
+            data: Vec::new(),
+            error_reason: reason as u8,
+            error_message: message,
+            no_content: false,
+        },
+    }
+}

--- a/src/renderer/file_source.rs
+++ b/src/renderer/file_source.rs
@@ -1,4 +1,4 @@
-//! Rust-supplied FileSource callback.
+//! Rust-supplied `FileSource` callback.
 //!
 //! Pair with the C++ side defined in `src/cpp/rust_file_source.{h,cpp}`. The
 //! Rust closure handed to

--- a/src/renderer/file_source.rs
+++ b/src/renderer/file_source.rs
@@ -1,15 +1,19 @@
 //! Rust-supplied `FileSource` callback.
 //!
 //! Pair with the C++ side defined in `src/cpp/rust_file_source.{h,cpp}`. The
-//! Rust closure handed to
-//! [`ImageRendererBuilder::with_file_source_callback`](crate::ImageRendererBuilder::with_file_source_callback)
-//! serves every resource mbgl asks for — styles, tilesets, tiles, glyphs,
-//! sprites, images. The URL scheme is not filtered on the C++ side, so the
-//! callback owns scheme dispatch (e.g. `mbtiles://`, `file://`, custom).
+//! Rust closure handed to [`register_file_source_callback`] serves every
+//! resource mbgl asks for — styles, tilesets, tiles, glyphs, sprites,
+//! images. The URL scheme is not filtered on the C++ side, so the callback
+//! owns scheme dispatch (e.g. `mbtiles://`, `file://`, custom).
 
+// Required by the `callback!` macro expansion: it emits
+// `impl Debug for $callback_name`, so `Debug` must be in scope as a
+// trait, not just a derive macro.
 use std::fmt::Debug;
 
-use crate::renderer::bridge::file_source::{FsErrorReason, ResourceKind};
+use crate::renderer::bridge::file_source::{
+    register_rust_file_source_factory, FsErrorReason, ResourceKind,
+};
 use crate::renderer::callbacks::callback;
 
 /// Return value for a resource request callback.
@@ -41,6 +45,45 @@ pub enum FsResponse {
 callback!(FileSourceRequestCallback,
           Fn(&str, ResourceKind) -> FsResponse,
           Send, Sync);
+
+/// Install a Rust closure as the `ResourceLoader` file-source callback for
+/// every subsequently constructed `mbgl::Map`.
+///
+/// The closure is invoked for every resource mbgl needs to render the
+/// style — tiles, glyphs, sprites, source manifests, etc. It replaces the
+/// mbgl default `ResourceLoader` entirely, so the closure owns URL-scheme
+/// dispatch (`mbtiles://`, `file://`, `https://`, custom).
+///
+/// # Process-global, with caching subtleties
+///
+/// `mbgl::FileSourceManager` is a process-wide singleton and this call
+/// mutates global state. There are two layers to be aware of:
+///
+/// 1. **Factory replacement.** A subsequent call replaces the registered
+///    factory; the prior closure is dropped once no `RustFileSource`
+///    instance still references it.
+/// 2. **Instance cache.** `FileSourceManager` *also* caches `FileSource`
+///    instances keyed by `(type, ResourceOptions)`. `getFileSource` returns
+///    the cached instance via `weak_ptr::lock()` whenever it's still alive,
+///    bypassing the factory. So replacing the callback while any prior
+///    renderer (built with the same `ResourceOptions`) is still in scope
+///    has no effect on either the prior renderer *or* on new renderers
+///    that share its `ResourceOptions` — they all keep using the original
+///    closure until the cached instance is dropped.
+///
+/// In practice: install the callback once, before constructing any
+/// renderer, and keep it for the process lifetime. Two concurrent
+/// renderers requiring different callbacks are not supported by this
+/// layer.
+///
+/// `Send + Sync` are required because mbgl may invoke the same closure
+/// from multiple renderer threads concurrently.
+pub fn register_file_source_callback<F>(callback: F)
+where
+    F: Fn(&str, ResourceKind) -> FsResponse + Send + Sync + 'static,
+{
+    register_rust_file_source_factory(Box::new(FileSourceRequestCallback::new(callback)));
+}
 
 /// Bridge function invoked by C++ for every resource request. Not called
 /// directly from user code — exposed via the cxx bridge in

--- a/src/renderer/file_source.rs
+++ b/src/renderer/file_source.rs
@@ -9,66 +9,8 @@
 
 use std::fmt::Debug;
 
+use crate::renderer::bridge::file_source::{FsErrorReason, ResourceKind};
 use crate::renderer::callbacks::callback;
-
-/// Kind of resource being requested. Mirrors `mbgl::Resource::Kind` from
-/// `mbgl/storage/resource.hpp`; discriminant values are pinned byte-for-byte
-/// to that enum by `static_assert`s in `rust_file_source.cpp`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-pub enum ResourceKind {
-    /// Unknown / unspecified resource kind.
-    Unknown = 0,
-    /// A style.json.
-    Style = 1,
-    /// A TileJSON / source descriptor.
-    Source = 2,
-    /// A single tile (vector or raster).
-    Tile = 3,
-    /// A glyph PBF range.
-    Glyphs = 4,
-    /// A sprite sheet PNG.
-    SpriteImage = 5,
-    /// A sprite sheet JSON.
-    SpriteJSON = 6,
-    /// A generic image resource.
-    Image = 7,
-}
-
-impl ResourceKind {
-    fn from_u8(v: u8) -> Self {
-        match v {
-            1 => Self::Style,
-            2 => Self::Source,
-            3 => Self::Tile,
-            4 => Self::Glyphs,
-            5 => Self::SpriteImage,
-            6 => Self::SpriteJSON,
-            7 => Self::Image,
-            _ => Self::Unknown,
-        }
-    }
-}
-
-/// Error reason for a failed resource request. Mirrors
-/// `mbgl::Response::Error::Reason`; discriminant values are pinned to that
-/// enum by `static_assert`s in `rust_file_source.cpp`. The `0` discriminant
-/// is intentionally reserved on the FFI side to mean "no error" —
-/// `mbgl::Response::Error::Reason` starts at `Success = 1`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-pub enum FsErrorReason {
-    /// Resource not found at the requested URL.
-    NotFound = 2,
-    /// Server-side error (5xx, etc.).
-    Server = 3,
-    /// Transport-level connection failure.
-    Connection = 4,
-    /// Rate-limit response.
-    RateLimit = 5,
-    /// Any other error.
-    Other = 6,
-}
 
 /// Return value for a resource request callback.
 #[derive(Debug)]
@@ -80,7 +22,9 @@ pub enum FsResponse {
     /// body. Overzoomed tiles should use this rather than [`FsResponse::Error`].
     NoContent,
     /// Request failed. The reason maps directly to the mbgl error enum so
-    /// mbgl-internal retry/backoff logic still applies.
+    /// mbgl-internal retry/backoff logic still applies. Don't use
+    /// [`FsErrorReason::Success`] here — pick `Other` if no other variant
+    /// fits.
     Error {
         /// Category of failure.
         reason: FsErrorReason,
@@ -104,25 +48,25 @@ callback!(FileSourceRequestCallback,
 pub(crate) fn fs_request_callback(
     callback: &FileSourceRequestCallback,
     url: &str,
-    kind: u8,
+    kind: ResourceKind,
 ) -> crate::renderer::bridge::file_source::RustFsResponse {
     use crate::renderer::bridge::file_source::RustFsResponse;
-    match (callback.0)(url, ResourceKind::from_u8(kind)) {
+    match (callback.0)(url, kind) {
         FsResponse::Ok(bytes) => RustFsResponse {
             data: bytes,
-            error_reason: 0,
+            error_reason: FsErrorReason::Success,
             error_message: String::new(),
             no_content: false,
         },
         FsResponse::NoContent => RustFsResponse {
             data: Vec::new(),
-            error_reason: 0,
+            error_reason: FsErrorReason::Success,
             error_message: String::new(),
             no_content: true,
         },
         FsResponse::Error { reason, message } => RustFsResponse {
             data: Vec::new(),
-            error_reason: reason as u8,
+            error_reason: reason,
             error_message: message,
             no_content: false,
         },

--- a/src/renderer/file_source.rs
+++ b/src/renderer/file_source.rs
@@ -51,6 +51,8 @@ pub(crate) fn fs_request_callback(
     kind: ResourceKind,
 ) -> crate::renderer::bridge::file_source::RustFsResponse {
     use crate::renderer::bridge::file_source::RustFsResponse;
+    #[cfg(feature = "log")]
+    log::debug!("rust-fs request kind={kind:?} url={url}");
     match (callback.0)(url, kind) {
         FsResponse::Ok(bytes) => RustFsResponse {
             data: bytes,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -15,7 +15,7 @@ pub use bridge::{
     set_log_thread_enabled, Height, ScreenCoordinate, Size, Width, X, Y,
 };
 pub use builder::ImageRendererBuilder;
-pub use file_source::{FileSourceRequestCallback, FsResponse};
+pub use file_source::{register_file_source_callback, FileSourceRequestCallback, FsResponse};
 pub use image_renderer::{Continuous, Image, ImageRenderer, RenderingError, Static, Tile};
 pub use map_observer::MapObserver;
 pub use resource_options::ResourceOptions;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -14,9 +14,7 @@ pub use bridge::{
     set_log_thread_enabled, Height, ScreenCoordinate, Size, Width, X, Y,
 };
 pub use builder::ImageRendererBuilder;
-pub use file_source::{
-    FileSourceRequestCallback, FsErrorReason, FsResponse, ResourceKind,
-};
+pub use file_source::{FileSourceRequestCallback, FsErrorReason, FsResponse, ResourceKind};
 pub use image_renderer::{Continuous, Image, ImageRenderer, RenderingError, Static, Tile};
 pub use map_observer::MapObserver;
 pub use resource_options::ResourceOptions;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod bridge;
 mod builder;
 pub mod callbacks;
+pub mod file_source;
 mod image_renderer;
 mod map_observer;
 mod resource_options;
@@ -13,6 +14,9 @@ pub use bridge::{
     set_log_thread_enabled, Height, ScreenCoordinate, Size, Width, X, Y,
 };
 pub use builder::ImageRendererBuilder;
+pub use file_source::{
+    FileSourceRequestCallback, FsErrorReason, FsResponse, ResourceKind,
+};
 pub use image_renderer::{Continuous, Image, ImageRenderer, RenderingError, Static, Tile};
 pub use map_observer::MapObserver;
 pub use resource_options::ResourceOptions;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -14,7 +14,8 @@ pub use bridge::{
     set_log_thread_enabled, Height, ScreenCoordinate, Size, Width, X, Y,
 };
 pub use builder::ImageRendererBuilder;
-pub use file_source::{FileSourceRequestCallback, FsErrorReason, FsResponse, ResourceKind};
+pub use bridge::file_source::{FsErrorReason, ResourceKind};
+pub use file_source::{FileSourceRequestCallback, FsResponse};
 pub use image_renderer::{Continuous, Image, ImageRenderer, RenderingError, Static, Tile};
 pub use map_observer::MapObserver;
 pub use resource_options::ResourceOptions;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -7,6 +7,7 @@ mod map_observer;
 mod resource_options;
 pub mod style;
 pub mod tile_server_options;
+pub use bridge::file_source::{FsErrorReason, ResourceKind};
 pub use bridge::{
     ffi::{MapDebugOptions, MapMode},
     layers,
@@ -14,7 +15,6 @@ pub use bridge::{
     set_log_thread_enabled, Height, ScreenCoordinate, Size, Width, X, Y,
 };
 pub use builder::ImageRendererBuilder;
-pub use bridge::file_source::{FsErrorReason, ResourceKind};
 pub use file_source::{FileSourceRequestCallback, FsResponse};
 pub use image_renderer::{Continuous, Image, ImageRenderer, RenderingError, Static, Tile};
 pub use map_observer::MapObserver;

--- a/tests/file_source_callback.rs
+++ b/tests/file_source_callback.rs
@@ -11,9 +11,7 @@ use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-use maplibre_native::{
-    FsResponse, Height, ImageRendererBuilder, ResourceKind, Size, Width,
-};
+use maplibre_native::{FsResponse, Height, ImageRendererBuilder, ResourceKind, Size, Width};
 
 // A minimal style that renders a solid background. No tile sources — keeps
 // the test self-contained. We use a bright, unambiguous color so we can
@@ -62,9 +60,7 @@ fn file_source_callback_serves_inline_style() {
     renderer.load_style_from_url(&url);
     renderer.set_map_size(Size::new(Width(64), Height(64)));
 
-    let image = renderer
-        .render_static(0.0, 0.0, 0.0, 0.0, 0.0)
-        .expect("render should succeed");
+    let image = renderer.render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("render should succeed");
 
     // Dimensions: 64x64 logical * 1.0 ratio = 64x64 physical.
     let buf = image.as_image();
@@ -92,9 +88,11 @@ fn file_source_callback_serves_inline_style() {
     let mut saw_orange = false;
     for p in buf.pixels() {
         let [r, g, b, a] = p.0;
-        if a >= 250 && (r as i32 - 255).abs() <= 2
+        if a >= 250
+            && (r as i32 - 255).abs() <= 2
             && (g as i32 - 128).abs() <= 3
-            && (b as i32 - 0).abs() <= 2 {
+            && (b as i32 - 0).abs() <= 2
+        {
             saw_orange = true;
             break;
         }

--- a/tests/file_source_callback.rs
+++ b/tests/file_source_callback.rs
@@ -1,4 +1,4 @@
-//! End-to-end test for the Rust FileSource callback bridge.
+//! End-to-end test for the Rust `FileSource` callback bridge.
 //!
 //! Serves an inline style.json from the callback and renders it. Verifies:
 //! - the callback is actually invoked by mbgl
@@ -89,9 +89,9 @@ fn file_source_callback_serves_inline_style() {
     for p in buf.pixels() {
         let [r, g, b, a] = p.0;
         if a >= 250
-            && (r as i32 - 255).abs() <= 2
-            && (g as i32 - 128).abs() <= 3
-            && (b as i32 - 0).abs() <= 2
+            && (i32::from(r) - 255).abs() <= 2
+            && (i32::from(g) - 128).abs() <= 3
+            && i32::from(b) <= 2
         {
             saw_orange = true;
             break;

--- a/tests/file_source_callback.rs
+++ b/tests/file_source_callback.rs
@@ -1,0 +1,103 @@
+//! End-to-end test for the Rust FileSource callback bridge.
+//!
+//! Serves an inline style.json from the callback and renders it. Verifies:
+//! - the callback is actually invoked by mbgl
+//! - the URLs we receive match the documented `file://` scheme for
+//!   `load_style_from_path`
+//! - the rendered image has the expected dimensions and non-zero content
+//!   (the background-color pixels, not all transparent).
+
+use std::num::NonZeroU32;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use maplibre_native::{
+    FsResponse, Height, ImageRendererBuilder, ResourceKind, Size, Width,
+};
+
+// A minimal style that renders a solid background. No tile sources — keeps
+// the test self-contained. We use a bright, unambiguous color so we can
+// assert it round-trips through the render pipeline.
+const INLINE_STYLE: &str = r#"{
+    "version": 8,
+    "name": "callback-test",
+    "sources": {},
+    "layers": [
+        { "id": "bg", "type": "background", "paint": { "background-color": "rgb(255, 128, 0)" } }
+    ]
+}"#;
+
+#[test]
+fn file_source_callback_serves_inline_style() {
+    // Record every URL the callback sees so we can assert mbgl actually
+    // called us. Use Arc<Mutex<Vec>> because the closure is Send + Sync.
+    let seen_urls: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let call_count = Arc::new(AtomicUsize::new(0));
+
+    let seen_urls_cb = seen_urls.clone();
+    let call_count_cb = call_count.clone();
+
+    let mut renderer = ImageRendererBuilder::new()
+        .with_size(NonZeroU32::new(64).unwrap(), NonZeroU32::new(64).unwrap())
+        .with_pixel_ratio(1.0)
+        .with_file_source_callback(move |url: &str, kind: ResourceKind| {
+            call_count_cb.fetch_add(1, Ordering::SeqCst);
+            seen_urls_cb.lock().unwrap().push(format!("{kind:?}:{url}"));
+
+            if url.ends_with("/inline-style.json") {
+                FsResponse::Ok(INLINE_STYLE.as_bytes().to_vec())
+            } else {
+                // Style has no other resources, but mbgl may still probe
+                // sprites/glyphs. Return NoContent for everything else —
+                // mbgl renders the background without sprites/glyphs.
+                FsResponse::NoContent
+            }
+        })
+        .build_static_renderer();
+
+    // Use a bogus URL — our callback doesn't care about the prefix, only the
+    // `/inline-style.json` suffix. Go through `load_style_from_url` rather
+    // than `load_style_from_path` so no file on disk is required.
+    let url: url::Url = "https://example.invalid/inline-style.json".parse().unwrap();
+    renderer.load_style_from_url(&url);
+    renderer.set_map_size(Size::new(Width(64), Height(64)));
+
+    let image = renderer
+        .render_static(0.0, 0.0, 0.0, 0.0, 0.0)
+        .expect("render should succeed");
+
+    // Dimensions: 64x64 logical * 1.0 ratio = 64x64 physical.
+    let buf = image.as_image();
+    assert_eq!(buf.width(), 64);
+    assert_eq!(buf.height(), 64);
+
+    // The callback must have been invoked at least once — for the style
+    // itself. (mbgl may also ask for sources/sprites/glyphs even though
+    // the style declares none; we return NoContent for those.)
+    let calls = call_count.load(Ordering::SeqCst);
+    assert!(calls >= 1, "expected ≥1 callback invocation, got {calls}");
+
+    // The first call must be the style URL we asked to load.
+    let urls = seen_urls.lock().unwrap();
+    assert!(!urls.is_empty());
+    assert!(
+        urls[0].contains("inline-style.json"),
+        "first callback url was not the style: {:?}",
+        urls[0]
+    );
+
+    // Background color is rgb(255, 128, 0) — find at least one pixel with
+    // that color in the output (mbgl may premultiply/unpremultiply so we
+    // allow ±2 tolerance).
+    let mut saw_orange = false;
+    for p in buf.pixels() {
+        let [r, g, b, a] = p.0;
+        if a >= 250 && (r as i32 - 255).abs() <= 2
+            && (g as i32 - 128).abs() <= 3
+            && (b as i32 - 0).abs() <= 2 {
+            saw_orange = true;
+            break;
+        }
+    }
+    assert!(saw_orange, "expected to see rgb(255,128,0) pixels in the rendered image");
+}

--- a/tests/file_source_callback.rs
+++ b/tests/file_source_callback.rs
@@ -1,9 +1,8 @@
 //! End-to-end test for the Rust `FileSource` callback bridge.
 //!
 //! Serves an inline style.json from the callback and renders it. Verifies:
-//! - the callback is actually invoked by mbgl
-//! - the URLs we receive match the documented `file://` scheme for
-//!   `load_style_from_path`
+//! - the callback is actually invoked by mbgl for the style URL we asked
+//!   to load
 //! - the rendered image has the expected dimensions and non-zero content
 //!   (the background-color pixels, not all transparent).
 
@@ -11,7 +10,10 @@ use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-use maplibre_native::{FsResponse, Height, ImageRendererBuilder, ResourceKind, Size, Width};
+use maplibre_native::{
+    register_file_source_callback, FsResponse, Height, ImageRendererBuilder, ResourceKind, Size,
+    Width,
+};
 
 // A minimal style that renders a solid background. No tile sources — keeps
 // the test self-contained. We use a bright, unambiguous color so we can
@@ -35,22 +37,25 @@ fn file_source_callback_serves_inline_style() {
     let seen_urls_cb = seen_urls.clone();
     let call_count_cb = call_count.clone();
 
+    // Process-global registration: must happen before the renderer is
+    // built so mbgl picks up the factory at Map construction.
+    register_file_source_callback(move |url: &str, kind: ResourceKind| {
+        call_count_cb.fetch_add(1, Ordering::SeqCst);
+        seen_urls_cb.lock().unwrap().push(format!("{kind:?}:{url}"));
+
+        if url.ends_with("/inline-style.json") {
+            FsResponse::Ok(INLINE_STYLE.as_bytes().to_vec())
+        } else {
+            // Style has no other resources, but mbgl may still probe
+            // sprites/glyphs. Return NoContent for everything else —
+            // mbgl renders the background without sprites/glyphs.
+            FsResponse::NoContent
+        }
+    });
+
     let mut renderer = ImageRendererBuilder::new()
         .with_size(NonZeroU32::new(64).unwrap(), NonZeroU32::new(64).unwrap())
         .with_pixel_ratio(1.0)
-        .with_file_source_callback(move |url: &str, kind: ResourceKind| {
-            call_count_cb.fetch_add(1, Ordering::SeqCst);
-            seen_urls_cb.lock().unwrap().push(format!("{kind:?}:{url}"));
-
-            if url.ends_with("/inline-style.json") {
-                FsResponse::Ok(INLINE_STYLE.as_bytes().to_vec())
-            } else {
-                // Style has no other resources, but mbgl may still probe
-                // sprites/glyphs. Return NoContent for everything else —
-                // mbgl renders the background without sprites/glyphs.
-                FsResponse::NoContent
-            }
-        })
         .build_static_renderer();
 
     // Use a bogus URL — our callback doesn't care about the prefix, only the


### PR DESCRIPTION
 ## Summary

  Adds a Rust-supplied `FileSource` callback so consumers can serve every
  resource mbgl requests (styles, tilesets, tiles, glyphs, sprites) from
  arbitrary backends — `mbtiles://`, `file://`, private tile archives,
  in-memory stores — without running a sidecar HTTP server or
  pre-extracting tiles.

  ## Motivation

  Today the crate gives Rust callers no way to intercept resource
  requests. Consumers using `maplibre-native-rs` for non-HTTP backends
  (mbtiles being the most common example) have to either (a) front
  their data with Martin/tileserver-gl and pay a localhost HTTP hop
  per tile, or (b) pre-extract mbtiles into an XYZ directory and lose
  the SQLite lookup efficiency. This PR lets them read the data in
  place.

  ## API (additive, no existing API changes)

  ```rust
  use maplibre_native::{ImageRendererBuilder, FsResponse, ResourceKind};

  let mut renderer = ImageRendererBuilder::new()
      .with_size(w, h)
      .with_file_source_callback(|url: &str, kind: ResourceKind| {
          match kind {
              ResourceKind::Tile => load_tile_from_mbtiles(url),
              _                  => FsResponse::Ok(std::fs::read(url)?),
          }
      })
      .build_static_renderer();
```
  Public additions:

  - FileSourceRequestCallback — opaque callback handle, built via the
  existing callback! macro (extended to accept optional trait
  bounds so this callback can be Send + Sync)
  - FsResponse — Ok(Vec<u8>) | NoContent | Error { reason, message }
  - ResourceKind — mirrors mbgl::Resource::Kind
  - FsErrorReason — mirrors mbgl::Response::Error::Reason
  - ImageRendererBuilder::with_file_source_callback

  Implementation notes

  Pattern. C++ RustFileSource subclasses mbgl::FileSource and is
  installed via mbgl::FileSourceManager::registerFileSourceFactory
  for FileSourceType::ResourceLoader. Follows the existing
  MapObserver callback pattern in src/cpp/map_observer.h. The new
  cxx::bridge module file_source in src/renderer/bridge.rs
  follows the sibling layout of sources, layers, map_observer
  canonicalised in #149. build.rs picks up the two new C++ files via
  the existing BRIDGE_FILES iteration — no other build changes.

  Dispatch is synchronous. First iteration used
  mbgl::util::RunLoop::Get()->invokeCancellable to post the callback
  onto the current thread's run loop, reading the header comment on
  FileSource::request ("the callback will be called asynchronously,
  in the same thread as the request was made") as a scheduling
  requirement. In static-render mode that hangs at ~100% CPU:
  frontend->render(*map) does not pump the thread-local run loop at
  the point where style-load is blocked on the FileSource, so the
  posted task never executes. Synchronous dispatch from inside
  request() — matching what mbgl's in-memory FileSource test doubles
  do — unblocks style load immediately.

  Discriminant pinning. ResourceKind and FsErrorReason
  duplicate mbgl discriminants across the FFI boundary as raw u8.
  The C++ side has static_asserts for every discriminant, so an
  upstream mbgl enum reorder fails the build rather than silently
  remapping tile requests to sprite requests.

  Singleton contract documented. mbgl::FileSourceManager is a
  process-global singleton; the registered factory applies to every
  mbgl::Map constructed afterwards. Running two ImageRenderer
  instances in one process with different callbacks is unsupported —
  the builder docstring states this explicitly. Send + Sync bounds
  on the closure reflect that the same callback may be invoked from
  multiple render threads.

  Tests

  tests/file_source_callback.rs serves an inline background-only
  style via the callback, renders at 64×64, and asserts (a) the
  callback was invoked for the style URL, (b) the rendered image
  contains the background colour the style specifies. Passes in 0.38 s
  under cargo test --features vulkan.

  Also exercised in a downstream benchmark (not in this PR): 1000
  renders against a 1.6 GB OpenMapTiles mbtiles via a Rust-side SQLite
  reader. Steady-state RSS flat after ~100 renders, output
  pixel-close (~2% byte divergence, same framebuffer size) to the
  Node @maplibre/maplibre-gl-native binding on the same fixtures.

  Follow-ups (deliberately out of scope)

  - RenderingError surface unchanged. Callback errors currently flow
  through mbgl's retry/backoff and surface (if at all) via the
  existing FailingLoadingMapCallback for the style, or as missing
  tiles for other resources. Plumbing a RenderingError::ResourceLoader
  variant from observer events is a natural next step.
  - No unregister_rust_file_source_factory. Factory lives for the
  process; test isolation can be handled with different
  factory-per-test if needed later.

  Checklist

  - Test added (tests/file_source_callback.rs)
  - Clean against -Werror for C++ bridge (verified in Linux Docker)
  - No breaking API changes
  - Follows sibling-module layout established in #149
