### PR TITLE
chore: release v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6](https://github.com/maplibre/maplibre-native-rs/compare/v0.4.5...v0.4.6) - 2026-05-07
+
+### Added
+
+- *(renderer)* add Rust FileSource callback bridge ([#164](https://github.com/maplibre/maplibre-native-rs/pull/164))
+
 ## [0.4.5](https://github.com/maplibre/maplibre-native-rs/compare/v0.4.4...v0.4.5) - 2026-04-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.4.5"
+version = "0.4.6"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -78,7 +78,7 @@ futures = "0.3"
 image = "0.25"
 insta = "1.43"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.4.5" }
+maplibre_native = { path = ".", version = "0.4.6" }
 tar = "0.4.44"
 thiserror = "2.0.16"
 tokio = { version = "1", features = [], default-features = false }


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.4.5 -> 0.4.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.6](https://github.com/maplibre/maplibre-native-rs/compare/v0.4.5...v0.4.6) - 2026-05-07

### Added

- *(renderer)* add Rust FileSource callback bridge ([#164](https://github.com/maplibre/maplibre-native-rs/pull/164))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).