### PR TITLE
chore: replace `--revision` with the manual equivalent

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -351,7 +351,8 @@ fn build_local(
         // `git clone --revision` only exists in git >= 2.49 (May 2025); use
         // init + fetch + checkout so older git works too.
         let git = |args: &[&str]| -> Result<(), Box<dyn std::error::Error>> {
-            let status = Command::new("git").current_dir(&maplibre_native_dir).args(args).status()?;
+            let status =
+                Command::new("git").current_dir(&maplibre_native_dir).args(args).status()?;
             if !status.success() {
                 return Err(format!("git {} failed: {status}", args.join(" ")).into());
             }

--- a/build.rs
+++ b/build.rs
@@ -348,7 +348,7 @@ fn build_local(
     if !maplibre_native_dir.exists() {
         println!("cargo:warning=Cloning maplibre-native.");
         fs::create_dir_all(&maplibre_native_dir)?;
-        // `git clone --revision` only exists in git >= 2.49 (May 2025); use
+        // `git clone --revision` only exists in git >= 2.49 (March 2025); use
         // init + fetch + checkout so older git works too.
         let git = |args: &[&str]| -> Result<(), Box<dyn std::error::Error>> {
             let status =

--- a/build.rs
+++ b/build.rs
@@ -324,7 +324,7 @@ fn bundle_precompiled() -> Info {
 }
 
 fn build_local(
-    clone_dir: PathBuf,
+    clone_dir: &Path,
     name: &str,
     amalgam_lib: bool,
     target_os: &str,
@@ -482,7 +482,7 @@ fn build_mln() {
         let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
         let clone_dir = root.join("target");
 
-        match build_local(clone_dir.clone(), MAPLIBRE_NATIVE_DIR_NAME, amalgam_lib, &target_os) {
+        match build_local(&clone_dir, MAPLIBRE_NATIVE_DIR_NAME, amalgam_lib, &target_os) {
             Err(e) => {
                 if clone_dir.join(MAPLIBRE_NATIVE_DIR_NAME).exists() {
                     // let _ = fs::remove_dir_all(clone_dir.join(MAPLIBRE_NATIVE_DIR_NAME));

--- a/build.rs
+++ b/build.rs
@@ -347,24 +347,20 @@ fn build_local(
 
     if !maplibre_native_dir.exists() {
         println!("cargo:warning=Cloning maplibre-native.");
-        fs::create_dir_all(&clone_dir)?;
-        let clone_status = Command::new("git")
-            .current_dir(clone_dir)
-            .args([
-                "clone",
-                "--depth",
-                "1",
-                "--revision",
-                MLN_COMMIT,
-                "https://github.com/maplibre/maplibre-native.git",
-                name,
-            ])
-            .status()?;
-        if !clone_status.success() {
-            return Err(
-                format!("Failed to clone maplibre-native repository: {clone_status}").into()
-            );
-        }
+        fs::create_dir_all(&maplibre_native_dir)?;
+        // `git clone --revision` only exists in git >= 2.49 (May 2025); use
+        // init + fetch + checkout so older git works too.
+        let git = |args: &[&str]| -> Result<(), Box<dyn std::error::Error>> {
+            let status = Command::new("git").current_dir(&maplibre_native_dir).args(args).status()?;
+            if !status.success() {
+                return Err(format!("git {} failed: {status}", args.join(" ")).into());
+            }
+            Ok(())
+        };
+        git(&["init", "--quiet"])?;
+        git(&["remote", "add", "origin", "https://github.com/maplibre/maplibre-native.git"])?;
+        git(&["fetch", "--depth", "1", "origin", MLN_COMMIT])?;
+        git(&["checkout", "--quiet", "FETCH_HEAD"])?;
     }
     // println!("cargo:warning=Building maplibre-native.");
     println!("cargo:rerun-if-changed={}", maplibre_native_dir.as_os_str().to_str().unwrap());


### PR DESCRIPTION
more code, but also works on shitty OS-es that did not consider upgrading in the last year.
For example debian.. grrr..