### PR TITLE
feat(style): add GeoJSON and basic Fill/Line/Circle layer support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,6 @@ insta = { workspace = true, features = ["json", "redactions"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "sync", "rt-multi-thread"] }
 
-[lints]
-workspace = true
-
 ##########################################################
 ##########################################################
 ####  Workspace configuration for the entire project  ####
@@ -98,6 +95,9 @@ unused_qualifications = "warn"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
+
+[lints]
+workspace = true
 
 # https://insta.rs/docs/quickstart/
 [profile.dev.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,16 @@ default = ["log", "pool"]
 metal = []
 opengl = []
 vulkan = []
+geojson = ["dep:geojson", "dep:serde_json"]
 log = ["dep:log"]
 pool = ["dep:tokio"]
 
 [dependencies]
 cxx.workspace = true
+geojson = { workspace = true, optional = true }
 image.workspace = true
 log = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync"], optional = true }
 url.workspace = true
@@ -47,6 +50,7 @@ walkdir.workspace = true
 env_logger.workspace = true
 futures.workspace = true
 insta = { workspace = true, features = ["json", "redactions"] }
+serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "sync", "rt-multi-thread"] }
 
 [lints]
@@ -75,10 +79,12 @@ downloader = "0.2"
 env_logger = "0.11"
 flate2 = "1.1"
 futures = "0.3"
+geojson = "1.0.0"
 image = "0.25"
 insta = "1.43"
 log = "0.4"
 maplibre_native = { path = ".", version = "0.4.6" }
+serde_json = "1.0"
 tar = "0.4.44"
 thiserror = "2.0.16"
 tokio = { version = "1", features = [], default-features = false }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,3 @@
 allow-unwrap-in-tests = true
 avoid-breaking-exported-api = false
+doc-valid-idents = ["MapLibre", "GeoJSON", ".."]

--- a/examples/slint/Cargo.toml
+++ b/examples/slint/Cargo.toml
@@ -5,15 +5,21 @@ publish = false
 edition = "2024"
 
 [features]
-default = ["vulkan"]
+# Backend is selected per-OS through target-specific dependencies below. The
+# explicit features here let callers override (`cargo run --features ...`).
 vulkan = ["maplibre_native/vulkan"]
 opengl = ["maplibre_native/opengl"]
 metal = ["maplibre_native/metal"]
 
 [dependencies]
 image = { workspace = true }
-maplibre_native = { path = "../.." }
-slint = { version = "1.15", features = ["backend-android-activity-06"] }
+slint = { version = "1.16", features = ["backend-android-activity-06"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+maplibre_native = { path = "../..", features = ["metal"] }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+maplibre_native = { path = "../..", features = ["vulkan"] }
 
 [build-dependencies]
-slint-build = { version = "1.15" }
+slint-build = { version = "1.16" }

--- a/examples/slint/Cargo.toml
+++ b/examples/slint/Cargo.toml
@@ -7,19 +7,19 @@ edition = "2024"
 [features]
 # Backend is selected per-OS through target-specific dependencies below. The
 # explicit features here let callers override (`cargo run --features ...`).
-vulkan = ["maplibre_native/vulkan"]
-opengl = ["maplibre_native/opengl"]
 metal = ["maplibre_native/metal"]
+opengl = ["maplibre_native/opengl"]
+vulkan = ["maplibre_native/vulkan"]
 
 [dependencies]
 image = { workspace = true }
 slint = { version = "1.16", features = ["backend-android-activity-06"] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-maplibre_native = { path = "../..", features = ["metal"] }
-
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 maplibre_native = { path = "../..", features = ["vulkan"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+maplibre_native = { path = "../..", features = ["metal"] }
 
 [build-dependencies]
 slint-build = { version = "1.16" }

--- a/examples/slint/src/main.rs
+++ b/examples/slint/src/main.rs
@@ -2,11 +2,13 @@ mod maplibre;
 
 slint::include_modules!();
 
+const DEFAULT_WIDTH: u32 = 800;
+const DEFAULT_HEIGHT: u32 = 600;
+
 fn main() {
     let ui = MainWindow::new().unwrap();
-
-    let size = ui.get_map_size();
-    let map = maplibre::create_map(size);
+    let map =
+        maplibre::create_map(Size { width: DEFAULT_WIDTH as f32, height: DEFAULT_HEIGHT as f32 });
 
     maplibre::init(&ui, &map);
 

--- a/examples/slint/src/maplibre.rs
+++ b/examples/slint/src/maplibre.rs
@@ -1,18 +1,15 @@
 use crate::MainWindow;
 use crate::MapAdapter;
-use maplibre_native::Height;
-use maplibre_native::ScreenCoordinate;
-use maplibre_native::Width;
-use maplibre_native::layers::SymbolAnchorType;
 use slint::ComponentHandle;
 use std::rc::Rc;
 mod headless;
 pub use headless::MapLibre;
 pub use headless::create_map;
 use image::ImageReader;
-use maplibre_native::Style;
-use maplibre_native::{GeoJsonSource, Latitude, Longitude, SymbolLayer};
-use maplibre_native::{X, Y};
+use maplibre_native::{
+    CircleLayer, Color, FillLayer, GeoJson, GeoJsonSource, Height, LineLayer, ScreenCoordinate,
+    Style, SymbolLayer, Width, X, Y, layers::SymbolAnchorType,
+};
 use std::cell::RefCell;
 use std::path::Path;
 
@@ -110,11 +107,73 @@ fn style(map: &Rc<RefCell<MapLibre>>) {
     .unwrap();
     let image_id = style.add_image("The id", &image, true);
 
-    let mut geo_json_source = GeoJsonSource::new("geojsonsourceid");
-    geo_json_source.set_point(Latitude(52.67655), Longitude(13.28387));
-    let source_id = style.add_source(geo_json_source);
+    let mut shapes_source = GeoJsonSource::new("shapes-source");
+    let shapes = r#"{
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[
+                        [-30.0, -30.0],
+                        [30.0, -30.0],
+                        [30.0, 30.0],
+                        [-30.0, 30.0],
+                        [-30.0, -30.0]
+                    ]]
+                }
+            },
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[-60.0, 0.0], [60.0, 0.0]]
+                }
+            }
+        ]
+    }"#
+    .parse::<GeoJson>()
+    .expect("shapes GeoJSON should parse");
+    shapes_source.set_geojson(&shapes);
+    let shapes_id = style.add_source(shapes_source);
 
-    let layer = SymbolLayer::new("Layer id", &source_id);
+    let mut markers_source = GeoJsonSource::new("markers-source");
+    let markers = r#"{
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [13.28387, 52.67655]
+                }
+            }
+        ]
+    }"#
+    .parse::<GeoJson>()
+    .expect("marker GeoJSON should parse");
+    markers_source.set_geojson(&markers);
+    let markers_id = style.add_source(markers_source);
+
+    let mut fill = FillLayer::new("Fill layer id", &shapes_id);
+    fill.set_fill_color(Color::rgba(0.0, 0.45, 0.95, 0.35));
+    style.add_layer(fill);
+
+    let mut line = LineLayer::new("Line layer id", &shapes_id);
+    line.set_line_color(Color::rgb(0.0, 0.5, 0.8));
+    line.set_line_width(3.0);
+    style.add_layer(line);
+
+    let mut circle = CircleLayer::new("Circle layer id", &shapes_id);
+    circle.set_circle_color(Color::rgba(0.0, 0.7, 0.5, 0.85));
+    circle.set_circle_radius(7.0);
+    style.add_layer(circle);
+
+    let mut layer = SymbolLayer::new("Layer id", &markers_id);
     layer.set_icon_image(&image_id);
     layer.set_icon_anchor(SymbolAnchorType::Bottom);
     style.add_layer(layer);

--- a/examples/slint/src/maplibre/headless.rs
+++ b/examples/slint/src/maplibre/headless.rs
@@ -72,7 +72,10 @@ pub fn create_map(size: Size) -> Rc<RefCell<MapLibre>> {
         .with_pixel_ratio(1.0)
         .with_resource_options(resource_options)
         .build_continuous_renderer();
-    renderer.set_camera(Latitude(0.0), Longitude(0.0), 0.0, 0.0, 0.0); // setting the camera is important, otherwise map libre does nothing (no logs are comming and no map gets generated)
+
+    // setting the camera is important, otherwise maplibre does nothing
+    // (no logs are coming and no map gets generated).
+    renderer.set_camera(Latitude(0.0), Longitude(0.0), 0.0, 0.0, 0.0);
     renderer.load_style_from_url(&"https://demotiles.maplibre.org/style.json".parse().unwrap());
 
     let map = Rc::new(RefCell::new(MapLibre::new(renderer)));

--- a/src/cpp/geojson/geojson.cpp
+++ b/src/cpp/geojson/geojson.cpp
@@ -1,0 +1,26 @@
+#include "geojson.h"
+
+#include <string>
+#include <utility>
+
+namespace mln::bridge::geojson {
+
+GeoJson::GeoJson(mapbox::geojson::geojson value) : value_(std::move(value)) {}
+
+const mapbox::geojson::geojson& GeoJson::get() const {
+    return value_;
+}
+
+std::unique_ptr<GeoJson> parse(rust::Str json) {
+    return std::make_unique<GeoJson>(mapbox::geojson::parse(std::string(json)));
+}
+
+std::unique_ptr<GeoJson> clone(const GeoJson& geojson) {
+    return std::make_unique<GeoJson>(geojson.get());
+}
+
+rust::String stringify(const GeoJson& geojson) {
+    return mapbox::geojson::stringify(geojson.get());
+}
+
+} // namespace mln::bridge::geojson

--- a/src/cpp/geojson/geojson.h
+++ b/src/cpp/geojson/geojson.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <mapbox/geojson.hpp>
+#include "rust/cxx.h"
+#include <memory>
+
+namespace mln::bridge::geojson {
+
+class GeoJson {
+public:
+    explicit GeoJson(mapbox::geojson::geojson value);
+
+    const mapbox::geojson::geojson& get() const;
+
+private:
+    mapbox::geojson::geojson value_;
+};
+
+std::unique_ptr<GeoJson> parse(rust::Str json);
+
+std::unique_ptr<GeoJson> clone(const GeoJson& geojson);
+
+rust::String stringify(const GeoJson& geojson);
+
+} // namespace mln::bridge::geojson

--- a/src/cpp/layers/layers.cpp
+++ b/src/cpp/layers/layers.cpp
@@ -1,12 +1,63 @@
 #include "layers.h"
+#include <mbgl/style/layers/circle_layer.hpp>
+#include <mbgl/style/layers/fill_layer.hpp>
+#include <mbgl/style/layers/line_layer.hpp>
 #include <mbgl/style/layers/symbol_layer.hpp>
-#include <mbgl/style/property_value.hpp>
 #include <mbgl/style/expression/image.hpp>
+#include <mbgl/style/property_value.hpp>
 #include <mbgl/style/types.hpp>
 #include <memory>
 #include <string>
 
 namespace mln::bridge::style::layers {
+    std::unique_ptr<mbgl::style::CircleLayer> create_circle_layer(rust::Str layer_id, rust::Str source_id) {
+        return std::make_unique<mbgl::style::CircleLayer>(std::string(layer_id), std::string(source_id));
+    }
+
+    void setCircleColor(const std::unique_ptr<mbgl::style::CircleLayer>& layer, const mbgl::Color& color) {
+        layer->setCircleColor(mbgl::style::PropertyValue(color));
+    }
+
+    void setCircleOpacity(const std::unique_ptr<mbgl::style::CircleLayer>& layer, float opacity) {
+        layer->setCircleOpacity(mbgl::style::PropertyValue(opacity));
+    }
+
+    void setCircleRadius(const std::unique_ptr<mbgl::style::CircleLayer>& layer, float radius) {
+        layer->setCircleRadius(mbgl::style::PropertyValue(radius));
+    }
+
+    std::unique_ptr<mbgl::style::FillLayer> create_fill_layer(rust::Str layer_id, rust::Str source_id) {
+        return std::make_unique<mbgl::style::FillLayer>(std::string(layer_id), std::string(source_id));
+    }
+
+    void setFillColor(const std::unique_ptr<mbgl::style::FillLayer>& layer, const mbgl::Color& color) {
+        layer->setFillColor(mbgl::style::PropertyValue(color));
+    }
+
+    void setFillOpacity(const std::unique_ptr<mbgl::style::FillLayer>& layer, float opacity) {
+        layer->setFillOpacity(mbgl::style::PropertyValue(opacity));
+    }
+
+    void setFillOutlineColor(const std::unique_ptr<mbgl::style::FillLayer>& layer, const mbgl::Color& color) {
+        layer->setFillOutlineColor(mbgl::style::PropertyValue(color));
+    }
+
+    std::unique_ptr<mbgl::style::LineLayer> create_line_layer(rust::Str layer_id, rust::Str source_id) {
+        return std::make_unique<mbgl::style::LineLayer>(std::string(layer_id), std::string(source_id));
+    }
+
+    void setLineColor(const std::unique_ptr<mbgl::style::LineLayer>& layer, const mbgl::Color& color) {
+        layer->setLineColor(mbgl::style::PropertyValue(color));
+    }
+
+    void setLineOpacity(const std::unique_ptr<mbgl::style::LineLayer>& layer, float opacity) {
+        layer->setLineOpacity(mbgl::style::PropertyValue(opacity));
+    }
+
+    void setLineWidth(const std::unique_ptr<mbgl::style::LineLayer>& layer, float width) {
+        layer->setLineWidth(mbgl::style::PropertyValue(width));
+    }
+
     std::unique_ptr<mbgl::style::SymbolLayer> create_symbol_layer(rust::Str layer_id, rust::Str source_id) {
         return std::make_unique<mbgl::style::SymbolLayer>(std::string(layer_id), std::string(source_id));
     }

--- a/src/cpp/layers/layers.h
+++ b/src/cpp/layers/layers.h
@@ -1,14 +1,33 @@
 #include <memory>
 
 #include <mbgl/style/types.hpp>
+#include <mbgl/util/color.hpp>
 
 #include "rust/cxx.h"
 
 namespace mbgl::style {
+    class CircleLayer;
+    class FillLayer;
+    class LineLayer;
     class SymbolLayer;
 }
 
 namespace mln::bridge::style::layers {
+    std::unique_ptr<mbgl::style::CircleLayer> create_circle_layer(rust::Str layer_id, rust::Str source_id);
+    void setCircleColor(const std::unique_ptr<mbgl::style::CircleLayer>& layer, const mbgl::Color& color);
+    void setCircleOpacity(const std::unique_ptr<mbgl::style::CircleLayer>& layer, float opacity);
+    void setCircleRadius(const std::unique_ptr<mbgl::style::CircleLayer>& layer, float radius);
+
+    std::unique_ptr<mbgl::style::FillLayer> create_fill_layer(rust::Str layer_id, rust::Str source_id);
+    void setFillColor(const std::unique_ptr<mbgl::style::FillLayer>& layer, const mbgl::Color& color);
+    void setFillOpacity(const std::unique_ptr<mbgl::style::FillLayer>& layer, float opacity);
+    void setFillOutlineColor(const std::unique_ptr<mbgl::style::FillLayer>& layer, const mbgl::Color& color);
+
+    std::unique_ptr<mbgl::style::LineLayer> create_line_layer(rust::Str layer_id, rust::Str source_id);
+    void setLineColor(const std::unique_ptr<mbgl::style::LineLayer>& layer, const mbgl::Color& color);
+    void setLineOpacity(const std::unique_ptr<mbgl::style::LineLayer>& layer, float opacity);
+    void setLineWidth(const std::unique_ptr<mbgl::style::LineLayer>& layer, float width);
+
     std::unique_ptr<mbgl::style::SymbolLayer> create_symbol_layer(rust::Str layer_id, rust::Str source_id);
     void setIconImage(const std::unique_ptr<mbgl::style::SymbolLayer>& layer, rust::Str image_id);
     void setIconAnchor(const std::unique_ptr<mbgl::style::SymbolLayer>& layer, mbgl::style::SymbolAnchorType anchor);

--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -2,8 +2,11 @@
 
 #include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/style/image.hpp>
-#include <mbgl/style/sources/geojson_source.hpp>
+#include <mbgl/style/layers/circle_layer.hpp>
+#include <mbgl/style/layers/fill_layer.hpp>
+#include <mbgl/style/layers/line_layer.hpp>
 #include <mbgl/style/layers/symbol_layer.hpp>
+#include <mbgl/style/sources/geojson_source.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/style/style.hpp>
@@ -56,6 +59,18 @@ public:
 
     void style_add_geojson_source(std::unique_ptr<mbgl::style::GeoJSONSource> source) {
         map->getStyle().addSource(std::move(source));
+    }
+
+    void style_add_circle_layer(std::unique_ptr<mbgl::style::CircleLayer> layer) {
+        map->getStyle().addLayer(std::move(layer));
+    }
+
+    void style_add_fill_layer(std::unique_ptr<mbgl::style::FillLayer> layer) {
+        map->getStyle().addLayer(std::move(layer));
+    }
+
+    void style_add_line_layer(std::unique_ptr<mbgl::style::LineLayer> layer) {
+        map->getStyle().addLayer(std::move(layer));
     }
 
     void style_add_symbol_layer(std::unique_ptr<mbgl::style::SymbolLayer> layer) {

--- a/src/cpp/sources/sources.cpp
+++ b/src/cpp/sources/sources.cpp
@@ -1,6 +1,6 @@
 #include "sources.h"
+#include "geojson/geojson.h"
 #include <mbgl/style/sources/geojson_source.hpp>
-#include <mbgl/util/geometry.hpp>
 #include <memory>
 
 namespace mln::bridge::style::sources::geojson {
@@ -8,7 +8,8 @@ namespace mln::bridge::style::sources::geojson {
         return std::make_unique<mbgl::style::GeoJSONSource>(std::string(id));
     }
 
-    void setPoint(const std::unique_ptr<mbgl::style::GeoJSONSource>& source, double latitude, double longitude) {
-        source->setGeoJSON(mbgl::Geometry<double>{mbgl::Point<double>{longitude, latitude}});
+    void setGeoJson(const std::unique_ptr<mbgl::style::GeoJSONSource>& source,
+                    const mln::bridge::geojson::GeoJson& geojson) {
+        source->setGeoJSON(geojson.get());
     }
 }

--- a/src/cpp/sources/sources.h
+++ b/src/cpp/sources/sources.h
@@ -6,8 +6,13 @@ namespace mbgl::style {
     class GeoJSONSource;
 }
 
+namespace mln::bridge::geojson {
+    class GeoJson;
+}
+
 namespace mln::bridge::style::sources::geojson {
     std::unique_ptr<mbgl::style::GeoJSONSource> create(rust::Str id);
 
-    void setPoint(const std::unique_ptr<mbgl::style::GeoJSONSource>& source, double latitude, double longitude);
+    void setGeoJson(const std::unique_ptr<mbgl::style::GeoJSONSource>& source,
+                    const mln::bridge::geojson::GeoJson& geojson);
 }

--- a/src/renderer/bridge.rs
+++ b/src/renderer/bridge.rs
@@ -18,6 +18,9 @@ pub fn set_log_thread_enabled(enable: bool) {
 }
 
 fn log_from_cpp(severity: ffi::EventSeverity, event: ffi::Event, code: i64, message: &str) {
+    #[cfg(not(feature = "log"))]
+    let _ = (severity, event, code, message);
+
     #[cfg(feature = "log")]
     match severity {
         ffi::EventSeverity::Debug => log::debug!("{event:?} (code={code}) {message}"),
@@ -100,6 +103,31 @@ impl Size {
 }
 
 #[cxx::bridge()]
+/// FFI bindings for GeoJSON values.
+pub mod geojson {
+    #[namespace = "mln::bridge::geojson"]
+    unsafe extern "C++" {
+        include!("geojson/geojson.h");
+
+        /// A MapLibre Native GeoJSON value.
+        type GeoJson;
+
+        /// Parses a GeoJSON string into a MapLibre Native GeoJSON value.
+        fn parse(json: &str) -> Result<UniquePtr<GeoJson>>;
+        /// Copies a MapLibre Native GeoJSON value.
+        fn clone(geojson: &GeoJson) -> UniquePtr<GeoJson>;
+        /// Serializes a MapLibre Native GeoJSON value to a JSON string.
+        fn stringify(geojson: &GeoJson) -> Result<String>;
+    }
+}
+
+impl std::fmt::Debug for geojson::GeoJson {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GeoJson").finish()
+    }
+}
+
+#[cxx::bridge()]
 /// FFI bindings for map source operations.
 ///
 /// This module provides C++/Rust interoperability for various source types.
@@ -113,14 +141,23 @@ pub mod sources {
         type GeoJSONSource;
     }
 
+    #[namespace = "mln::bridge::geojson"]
+    extern "C++" {
+        include!("geojson/geojson.h");
+
+        /// A MapLibre Native GeoJSON value.
+        #[rust_name = "CxxGeoJson"]
+        type GeoJson = super::geojson::GeoJson;
+    }
+
     #[namespace = "mln::bridge::style::sources::geojson"]
     unsafe extern "C++" {
         include!("sources/sources.h");
 
         /// Creates a new GeoJSON source with the given ID.
         fn create(id: &str) -> UniquePtr<GeoJSONSource>;
-        /// Sets a point for the GeoJSON source.
-        fn setPoint(source: &UniquePtr<GeoJSONSource>, latitude: f64, longitude: f64);
+        /// Sets the GeoJSON data for the source.
+        fn setGeoJson(source: &UniquePtr<GeoJSONSource>, geojson: &CxxGeoJson);
     }
 }
 
@@ -162,8 +199,18 @@ pub mod layers {
 
     #[namespace = "mbgl::style"]
     extern "C++" {
+        include!("mbgl/style/layers/circle_layer.hpp");
+        include!("mbgl/style/layers/fill_layer.hpp");
+        include!("mbgl/style/layers/line_layer.hpp");
         include!("mbgl/style/layers/symbol_layer.hpp");
         include!("mbgl/style/types.hpp");
+
+        /// A circle layer for rendering point data.
+        type CircleLayer;
+        /// A fill layer for rendering polygon data.
+        type FillLayer;
+        /// A line layer for rendering line data.
+        type LineLayer;
         // Opaque types
         /// A symbol layer for rendering labels and icons on the map.
         type SymbolLayer;
@@ -172,9 +219,50 @@ pub mod layers {
         type SymbolAnchorType;
     }
 
+    #[namespace = "mbgl"]
+    extern "C++" {
+        include!("mbgl/util/color.hpp");
+
+        /// A MapLibre Native premultiplied RGBA color.
+        type Color = super::super::style::Color;
+    }
+
     #[namespace = "mln::bridge::style::layers"]
     unsafe extern "C++" {
         include!("layers/layers.h");
+
+        /// Creates a new circle layer.
+        #[must_use]
+        pub(crate) fn create_circle_layer(
+            layer_id: &str,
+            source_id: &str,
+        ) -> UniquePtr<CircleLayer>;
+        /// Sets the circle color.
+        fn setCircleColor(layer: &UniquePtr<CircleLayer>, color: &Color);
+        /// Sets the circle opacity.
+        fn setCircleOpacity(layer: &UniquePtr<CircleLayer>, opacity: f32);
+        /// Sets the circle radius in pixels.
+        fn setCircleRadius(layer: &UniquePtr<CircleLayer>, radius: f32);
+
+        /// Creates a new fill layer.
+        #[must_use]
+        pub(crate) fn create_fill_layer(layer_id: &str, source_id: &str) -> UniquePtr<FillLayer>;
+        /// Sets the fill color.
+        fn setFillColor(layer: &UniquePtr<FillLayer>, color: &Color);
+        /// Sets the fill opacity.
+        fn setFillOpacity(layer: &UniquePtr<FillLayer>, opacity: f32);
+        /// Sets the fill outline color.
+        fn setFillOutlineColor(layer: &UniquePtr<FillLayer>, color: &Color);
+
+        /// Creates a new line layer.
+        #[must_use]
+        pub(crate) fn create_line_layer(layer_id: &str, source_id: &str) -> UniquePtr<LineLayer>;
+        /// Sets the line color.
+        fn setLineColor(layer: &UniquePtr<LineLayer>, color: &Color);
+        /// Sets the line opacity.
+        fn setLineOpacity(layer: &UniquePtr<LineLayer>, opacity: f32);
+        /// Sets the line width in pixels.
+        fn setLineWidth(layer: &UniquePtr<LineLayer>, width: f32);
 
         /// Creates a new symbol layer.
         #[must_use]
@@ -186,6 +274,24 @@ pub mod layers {
         fn setIconImage(layer: &UniquePtr<SymbolLayer>, image_id: &str);
         /// Sets the anchor point for layer icons.
         fn setIconAnchor(layer: &UniquePtr<SymbolLayer>, anchor: SymbolAnchorType);
+    }
+}
+
+impl std::fmt::Debug for layers::CircleLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CircleLayer").finish()
+    }
+}
+
+impl std::fmt::Debug for layers::FillLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FillLayer").finish()
+    }
+}
+
+impl std::fmt::Debug for layers::LineLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LineLayer").finish()
     }
 }
 
@@ -622,9 +728,18 @@ pub mod ffi {
 
     #[namespace = "mbgl::style"]
     extern "C++" {
+        /// Circle layer opaque type.
+        #[rust_name = "CxxCircleLayer"]
+        type CircleLayer = super::layers::CircleLayer;
+        /// Fill layer opaque type.
+        #[rust_name = "CxxFillLayer"]
+        type FillLayer = super::layers::FillLayer;
         /// GeoJSON source opaque type.
         #[rust_name = "CxxGeoJSONSource"]
         type GeoJSONSource = super::sources::GeoJSONSource;
+        /// Line layer opaque type.
+        #[rust_name = "CxxLineLayer"]
+        type LineLayer = super::layers::LineLayer;
         /// Symbol layer opaque type.
         #[rust_name = "CxxSymbolLayer"]
         type SymbolLayer = super::layers::SymbolLayer;
@@ -698,6 +813,12 @@ pub mod ffi {
             self: Pin<&mut MapRenderer>,
             source: UniquePtr<CxxGeoJSONSource>,
         );
+        /// Adds a circle layer to the style.
+        fn style_add_circle_layer(self: Pin<&mut MapRenderer>, layer: UniquePtr<CxxCircleLayer>);
+        /// Adds a fill layer to the style.
+        fn style_add_fill_layer(self: Pin<&mut MapRenderer>, layer: UniquePtr<CxxFillLayer>);
+        /// Adds a line layer to the style.
+        fn style_add_line_layer(self: Pin<&mut MapRenderer>, layer: UniquePtr<CxxLineLayer>);
         /// Adds a symbol layer to the style.
         fn style_add_symbol_layer(self: Pin<&mut MapRenderer>, layer: UniquePtr<CxxSymbolLayer>);
     }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -19,11 +19,15 @@ pub use file_source::{register_file_source_callback, FileSourceRequestCallback, 
 pub use image_renderer::{Continuous, Image, ImageRenderer, RenderingError, Static, Tile};
 pub use map_observer::MapObserver;
 pub use resource_options::ResourceOptions;
-pub use style::GeoJsonSource;
-pub use style::SourceId;
-pub use style::Style;
-pub use style::StyleLayer;
-pub use style::StyleSource;
-pub use style::StyleSourceRef;
-pub use style::SymbolLayer;
-pub use style::{Latitude, Longitude};
+pub use style::{
+    CircleLayer, Color, FillLayer, GeoJson, GeoJsonError, GeoJsonSource, LineLayer, SourceId,
+    Style, StyleLayer, StyleSource, StyleSourceRef, SymbolLayer,
+};
+
+/// Latitude coordinate value.
+#[derive(Debug, Clone, Copy)]
+pub struct Latitude(pub f64);
+
+/// Longitude coordinate value.
+#[derive(Debug, Clone, Copy)]
+pub struct Longitude(pub f64);

--- a/src/renderer/style.rs
+++ b/src/renderer/style.rs
@@ -46,10 +46,13 @@ impl Color {
     /// Panics if any channel is outside the `0.0..=1.0` range.
     #[must_use]
     pub fn rgba(red: f32, green: f32, blue: f32, alpha: f32) -> Self {
-        assert!((0.0..=1.0).contains(&red));
-        assert!((0.0..=1.0).contains(&green));
-        assert!((0.0..=1.0).contains(&blue));
-        assert!((0.0..=1.0).contains(&alpha));
+        assert!(
+            (0.0..=1.0).contains(&red)
+                && (0.0..=1.0).contains(&green)
+                && (0.0..=1.0).contains(&blue)
+                && (0.0..=1.0).contains(&alpha),
+            "color channels must be in the 0.0..=1.0 range; got rgba({red}, {green}, {blue}, {alpha})",
+        );
         Self { r: red * alpha, g: green * alpha, b: blue * alpha, a: alpha }
     }
 }

--- a/src/renderer/style.rs
+++ b/src/renderer/style.rs
@@ -40,6 +40,10 @@ impl Color {
     }
 
     /// Creates an RGBA color from channel values in the `0.0..=1.0` range.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any channel is outside the `0.0..=1.0` range.
     #[must_use]
     pub fn rgba(red: f32, green: f32, blue: f32, alpha: f32) -> Self {
         assert!((0.0..=1.0).contains(&red));

--- a/src/renderer/style.rs
+++ b/src/renderer/style.rs
@@ -1,14 +1,59 @@
 //! Style abstractions for sources, layers, and images.
 
+mod circle_layer;
+mod fill_layer;
+mod geojson;
+mod geojson_source;
+mod line_layer;
+mod symbol_layer;
+
+use image::DynamicImage;
+
 use crate::renderer::bridge::ffi::Size;
 use crate::ImageRenderer;
-use image::DynamicImage;
-mod symbol_layer;
-pub use symbol_layer::SymbolLayer;
-mod geojson_source;
+pub use circle_layer::CircleLayer;
+pub use fill_layer::FillLayer;
+pub use geojson::{GeoJson, GeoJsonError};
 pub use geojson_source::GeoJsonSource;
-pub use geojson_source::Latitude;
-pub use geojson_source::Longitude;
+pub use line_layer::LineLayer;
+pub use symbol_layer::SymbolLayer;
+
+/// A color constructed from straight RGBA channels in the `0.0..=1.0` range.
+///
+/// MapLibre Native stores colors as premultiplied RGBA. Constructors on this
+/// type accept straight RGBA and store the premultiplied representation expected
+/// by MapLibre Native.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Color {
+    r: f32,
+    g: f32,
+    b: f32,
+    a: f32,
+}
+
+impl Color {
+    /// Creates an opaque RGB color from channel values in the `0.0..=1.0` range.
+    #[must_use]
+    pub fn rgb(red: f32, green: f32, blue: f32) -> Self {
+        Self::rgba(red, green, blue, 1.0)
+    }
+
+    /// Creates an RGBA color from channel values in the `0.0..=1.0` range.
+    #[must_use]
+    pub fn rgba(red: f32, green: f32, blue: f32, alpha: f32) -> Self {
+        assert!((0.0..=1.0).contains(&red));
+        assert!((0.0..=1.0).contains(&green));
+        assert!((0.0..=1.0).contains(&blue));
+        assert!((0.0..=1.0).contains(&alpha));
+        Self { r: red * alpha, g: green * alpha, b: blue * alpha, a: alpha }
+    }
+}
+
+unsafe impl cxx::ExternType for Color {
+    type Id = cxx::type_id!("mbgl::Color");
+    type Kind = cxx::kind::Trivial;
+}
 
 /// Shared interface for style sources that expose a stable source ID.
 pub trait StyleSourceRef {
@@ -59,6 +104,7 @@ impl StyleImageRef for ImageId {
 }
 
 /// A style source for rendering data layers.
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum StyleSource {
     /// A `GeoJSON` source.
@@ -66,8 +112,15 @@ pub enum StyleSource {
 }
 
 /// A style layer for rendering.
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum StyleLayer {
+    /// A circle layer.
+    Circle(CircleLayer),
+    /// A fill layer.
+    Fill(FillLayer),
+    /// A line layer.
+    Line(LineLayer),
     /// A symbol layer.
     Symbol(SymbolLayer),
 }
@@ -129,9 +182,33 @@ impl<'a, S> Style<'a, S> {
     /// Add a new layer
     pub fn add_layer<T: Into<StyleLayer>>(&mut self, layer: T) {
         match layer.into() {
+            StyleLayer::Circle(layer) => {
+                self.image_renderer.instance.pin_mut().style_add_circle_layer(layer.into_inner());
+            }
+            StyleLayer::Fill(layer) => {
+                self.image_renderer.instance.pin_mut().style_add_fill_layer(layer.into_inner());
+            }
+            StyleLayer::Line(layer) => {
+                self.image_renderer.instance.pin_mut().style_add_line_layer(layer.into_inner());
+            }
             StyleLayer::Symbol(layer) => {
                 self.image_renderer.instance.pin_mut().style_add_symbol_layer(layer.into_inner());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Color;
+
+    #[test]
+    fn rgba_stores_premultiplied_channels() {
+        assert_eq!(Color::rgba(1.0, 0.0, 0.0, 0.5), Color { r: 0.5, g: 0.0, b: 0.0, a: 0.5 });
+    }
+
+    #[test]
+    fn rgb_stores_opaque_channels() {
+        assert_eq!(Color::rgb(1.0, 0.0, 0.0), Color { r: 1.0, g: 0.0, b: 0.0, a: 1.0 });
     }
 }

--- a/src/renderer/style/circle_layer.rs
+++ b/src/renderer/style/circle_layer.rs
@@ -1,0 +1,48 @@
+use std::fmt;
+
+use cxx::UniquePtr;
+
+use crate::renderer::{bridge::layers, style::Color};
+
+/// A circle layer for rendering point data.
+pub struct CircleLayer {
+    layer: UniquePtr<layers::CircleLayer>,
+}
+
+impl CircleLayer {
+    /// Creates a new circle layer with the given layer and source IDs.
+    pub fn new<S: super::StyleSourceRef>(layer_id: &str, source: &S) -> Self {
+        Self { layer: layers::create_circle_layer(layer_id, source.source_id()) }
+    }
+
+    /// Sets the circle color.
+    pub fn set_circle_color(&mut self, color: Color) {
+        layers::setCircleColor(&self.layer, &color);
+    }
+
+    /// Sets the circle opacity.
+    pub fn set_circle_opacity(&mut self, opacity: f32) {
+        layers::setCircleOpacity(&self.layer, opacity);
+    }
+
+    /// Sets the circle radius in pixels.
+    pub fn set_circle_radius(&mut self, radius: f32) {
+        layers::setCircleRadius(&self.layer, radius);
+    }
+
+    pub(crate) fn into_inner(self) -> UniquePtr<layers::CircleLayer> {
+        self.layer
+    }
+}
+
+impl fmt::Debug for CircleLayer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CircleLayer").field("Pointer", &self.layer.as_ptr()).finish()
+    }
+}
+
+impl From<CircleLayer> for super::StyleLayer {
+    fn from(value: CircleLayer) -> Self {
+        Self::Circle(value)
+    }
+}

--- a/src/renderer/style/fill_layer.rs
+++ b/src/renderer/style/fill_layer.rs
@@ -1,0 +1,48 @@
+use std::fmt;
+
+use cxx::UniquePtr;
+
+use crate::renderer::{bridge::layers, style::Color};
+
+/// A fill layer for rendering polygon data.
+pub struct FillLayer {
+    layer: UniquePtr<layers::FillLayer>,
+}
+
+impl FillLayer {
+    /// Creates a new fill layer with the given layer and source IDs.
+    pub fn new<S: super::StyleSourceRef>(layer_id: &str, source: &S) -> Self {
+        Self { layer: layers::create_fill_layer(layer_id, source.source_id()) }
+    }
+
+    /// Sets the fill color.
+    pub fn set_fill_color(&mut self, color: Color) {
+        layers::setFillColor(&self.layer, &color);
+    }
+
+    /// Sets the fill opacity.
+    pub fn set_fill_opacity(&mut self, opacity: f32) {
+        layers::setFillOpacity(&self.layer, opacity);
+    }
+
+    /// Sets the fill outline color.
+    pub fn set_fill_outline_color(&mut self, color: Color) {
+        layers::setFillOutlineColor(&self.layer, &color);
+    }
+
+    pub(crate) fn into_inner(self) -> UniquePtr<layers::FillLayer> {
+        self.layer
+    }
+}
+
+impl fmt::Debug for FillLayer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FillLayer").field("Pointer", &self.layer.as_ptr()).finish()
+    }
+}
+
+impl From<FillLayer> for super::StyleLayer {
+    fn from(value: FillLayer) -> Self {
+        Self::Fill(value)
+    }
+}

--- a/src/renderer/style/geojson.rs
+++ b/src/renderer/style/geojson.rs
@@ -1,0 +1,164 @@
+use std::{fmt, str::FromStr};
+
+use cxx::UniquePtr;
+
+use crate::renderer::bridge::geojson;
+
+/// Error returned when creating a MapLibre Native GeoJSON value.
+#[derive(Debug, thiserror::Error)]
+pub enum GeoJsonError {
+    /// MapLibre Native rejected or failed to serialize the GeoJSON data.
+    #[error("GeoJSON error: {0}")]
+    Native(String),
+
+    /// The `geojson` crate value could not be serialized to JSON.
+    #[cfg(feature = "geojson")]
+    #[error("failed to serialize GeoJSON: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+/// A GeoJSON value prepared for MapLibre Native.
+///
+/// This type owns MapLibre Native's C++ GeoJSON representation.
+///
+/// MapLibre Native's GeoJSON representation is two-dimensional and silently
+/// drops `bbox`, foreign members, and any coordinate beyond X/Y, regardless of
+/// the construction path.
+pub struct GeoJson {
+    inner: UniquePtr<geojson::GeoJson>,
+}
+
+impl GeoJson {
+    fn from_json_str(json: &str) -> Result<Self, GeoJsonError> {
+        Ok(Self {
+            inner: geojson::parse(json).map_err(|error| GeoJsonError::Native(error.to_string()))?,
+        })
+    }
+
+    /// Serializes this value to a GeoJSON string using MapLibre Native.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if MapLibre Native fails to serialize the value.
+    pub fn to_json_string(&self) -> Result<String, GeoJsonError> {
+        geojson::stringify(&self.inner).map_err(|error| GeoJsonError::Native(error.to_string()))
+    }
+
+    pub(crate) fn as_inner(&self) -> &geojson::GeoJson {
+        self.inner.as_ref().expect("GeoJson bridge value is unexpectedly null")
+    }
+}
+
+#[cfg(feature = "geojson")]
+impl TryFrom<&::geojson::GeoJson> for GeoJson {
+    type Error = GeoJsonError;
+
+    fn try_from(value: &::geojson::GeoJson) -> Result<Self, Self::Error> {
+        Self::from_json_str(&serde_json::to_string(value)?)
+    }
+}
+
+#[cfg(feature = "geojson")]
+impl TryFrom<::geojson::GeoJson> for GeoJson {
+    type Error = GeoJsonError;
+
+    fn try_from(value: ::geojson::GeoJson) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+impl Clone for GeoJson {
+    fn clone(&self) -> Self {
+        Self { inner: geojson::clone(&self.inner) }
+    }
+}
+
+impl FromStr for GeoJson {
+    type Err = GeoJsonError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_json_str(s)
+    }
+}
+
+impl fmt::Debug for GeoJson {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GeoJson").finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GeoJson;
+
+    #[test]
+    fn parse_clone_and_stringify_geojson() {
+        let geojson = r#"{"type":"Point","coordinates":[1.0,2.0]}"#
+            .parse::<GeoJson>()
+            .expect("valid point GeoJSON should parse");
+        let cloned = geojson.clone();
+        let serialized = cloned.to_json_string().expect("valid GeoJSON should serialize");
+
+        assert!(serialized.contains(r#""Point""#));
+    }
+
+    #[test]
+    fn from_str_reports_invalid_geojson() {
+        assert!("not json".parse::<GeoJson>().is_err());
+    }
+
+    #[test]
+    fn from_str_drops_bbox_like_maplibre_native() {
+        let geojson = r#"{"type":"Point","bbox":[0,0,1,1],"coordinates":[1.0,2.0]}"#
+            .parse::<GeoJson>()
+            .expect("valid point GeoJSON should parse");
+
+        assert!(!geojson.to_json_string().expect("GeoJSON should serialize").contains("bbox"));
+    }
+
+    #[test]
+    fn from_str_drops_z_coordinates_like_maplibre_native() {
+        let geojson = r#"{"type":"Point","coordinates":[1.0,2.0,12345.6789]}"#
+            .parse::<GeoJson>()
+            .expect("valid 3D point GeoJSON should parse");
+        let serialized = geojson.to_json_string().expect("GeoJSON should serialize");
+        let json: serde_json::Value =
+            serde_json::from_str(&serialized).expect("serialized GeoJSON should parse as JSON");
+        let coordinates = json
+            .get("coordinates")
+            .and_then(serde_json::Value::as_array)
+            .expect("serialized point should have coordinate array");
+
+        assert_eq!(coordinates.len(), 2);
+    }
+
+    #[test]
+    fn clone_survives_original_drop() {
+        let cloned = {
+            let geojson = r#"{"type":"Point","coordinates":[1.0,2.0]}"#
+                .parse::<GeoJson>()
+                .expect("valid point GeoJSON should parse");
+            geojson.clone()
+        };
+
+        assert!(cloned
+            .to_json_string()
+            .expect("cloned GeoJSON should serialize")
+            .contains("Point"));
+    }
+
+    #[cfg(feature = "geojson")]
+    #[test]
+    fn converts_from_geojson_crate_value() {
+        let geojson = r#"{"type":"Feature","geometry":null,"properties":{"name":"empty"}}"#
+            .parse::<::geojson::GeoJson>()
+            .expect("valid geojson crate value should parse");
+        let converted = GeoJson::try_from(geojson)
+            .expect("geojson crate value should convert to MapLibre GeoJSON");
+
+        assert!(converted
+            .to_json_string()
+            .expect("converted GeoJSON should serialize")
+            .contains(r#""Feature""#));
+    }
+}

--- a/src/renderer/style/geojson_source.rs
+++ b/src/renderer/style/geojson_source.rs
@@ -1,31 +1,25 @@
-use crate::renderer::bridge::sources;
-use cxx::UniquePtr;
 use std::fmt;
 
-/// Latitude coordinate value.
-#[derive(Debug, Clone, Copy)]
-pub struct Latitude(pub f64);
+use cxx::UniquePtr;
 
-/// Longitude coordinate value.
-#[derive(Debug, Clone, Copy)]
-pub struct Longitude(pub f64);
+use crate::renderer::{bridge::sources, style::GeoJson};
 
-/// A `GeoJSON` source for rendering geographic data.
+/// A GeoJSON source for rendering geographic data.
 pub struct GeoJsonSource {
     source_id: String,
     source: UniquePtr<sources::GeoJSONSource>,
 }
 
 impl GeoJsonSource {
-    /// Create a new `GeoJSON` source
+    /// Create a new GeoJSON source
     #[must_use]
     pub fn new(id: &str) -> Self {
         Self { source_id: id.to_owned(), source: sources::create(id) }
     }
 
-    /// Sets the point for this source.
-    pub fn set_point(&mut self, latitude: Latitude, longitude: Longitude) {
-        sources::setPoint(&self.source, latitude.0, longitude.0);
+    /// Sets the GeoJSON data for this source.
+    pub fn set_geojson(&mut self, geojson: &GeoJson) {
+        sources::setGeoJson(&self.source, geojson.as_inner());
     }
 
     pub(crate) fn into_inner(self) -> UniquePtr<sources::GeoJSONSource> {

--- a/src/renderer/style/line_layer.rs
+++ b/src/renderer/style/line_layer.rs
@@ -1,0 +1,48 @@
+use std::fmt;
+
+use cxx::UniquePtr;
+
+use crate::renderer::{bridge::layers, style::Color};
+
+/// A line layer for rendering line data.
+pub struct LineLayer {
+    layer: UniquePtr<layers::LineLayer>,
+}
+
+impl LineLayer {
+    /// Creates a new line layer with the given layer and source IDs.
+    pub fn new<S: super::StyleSourceRef>(layer_id: &str, source: &S) -> Self {
+        Self { layer: layers::create_line_layer(layer_id, source.source_id()) }
+    }
+
+    /// Sets the line color.
+    pub fn set_line_color(&mut self, color: Color) {
+        layers::setLineColor(&self.layer, &color);
+    }
+
+    /// Sets the line opacity.
+    pub fn set_line_opacity(&mut self, opacity: f32) {
+        layers::setLineOpacity(&self.layer, opacity);
+    }
+
+    /// Sets the line width in pixels.
+    pub fn set_line_width(&mut self, width: f32) {
+        layers::setLineWidth(&self.layer, width);
+    }
+
+    pub(crate) fn into_inner(self) -> UniquePtr<layers::LineLayer> {
+        self.layer
+    }
+}
+
+impl fmt::Debug for LineLayer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LineLayer").field("Pointer", &self.layer.as_ptr()).finish()
+    }
+}
+
+impl From<LineLayer> for super::StyleLayer {
+    fn from(value: LineLayer) -> Self {
+        Self::Line(value)
+    }
+}

--- a/src/renderer/style/symbol_layer.rs
+++ b/src/renderer/style/symbol_layer.rs
@@ -1,6 +1,8 @@
-use crate::renderer::bridge::layers::{self, SymbolAnchorType};
-use cxx::UniquePtr;
 use std::fmt;
+
+use cxx::UniquePtr;
+
+use crate::renderer::bridge::layers::{self, SymbolAnchorType};
 
 /// A symbol layer for rendering labels and icons on the map.
 pub struct SymbolLayer {
@@ -20,12 +22,12 @@ impl SymbolLayer {
     }
 
     /// Set the icon used as marker
-    pub fn set_icon_image<T: super::StyleImageRef>(&self, image_id: &T) {
+    pub fn set_icon_image<T: super::StyleImageRef>(&mut self, image_id: &T) {
         layers::setIconImage(&self.layer, image_id.image_id());
     }
 
     /// Set the anchor point of the image
-    pub fn set_icon_anchor(&self, anchor: SymbolAnchorType) {
+    pub fn set_icon_anchor(&mut self, anchor: SymbolAnchorType) {
         layers::setIconAnchor(&self.layer, anchor);
     }
 

--- a/tests/style_geojson_layers.rs
+++ b/tests/style_geojson_layers.rs
@@ -1,0 +1,109 @@
+//! Integration tests for programmatic GeoJSON sources and data layers.
+
+use std::num::NonZeroU32;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use maplibre_native::{
+    CircleLayer, Color, FillLayer, GeoJson, GeoJsonSource, ImageRendererBuilder, LineLayer, Style,
+};
+
+const RENDER_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name)
+}
+
+fn has_non_background_pixel(image: &image::RgbaImage) -> bool {
+    image.pixels().any(|pixel| {
+        let [red, green, blue, alpha] = pixel.0;
+        alpha > 0 && !(red > 245 && blue > 220 && green < 20)
+    })
+}
+
+#[test]
+fn geojson_source_renders_circle_line_and_fill_layers() {
+    let mut renderer = ImageRendererBuilder::new()
+        .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
+        .with_pixel_ratio(1.0)
+        .build_static_renderer();
+
+    renderer.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
+    let background =
+        renderer.render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("background style should render");
+    assert_eq!(background.as_image().width(), 128);
+
+    let mut source = GeoJsonSource::new("geojson-test-source");
+    let geojson = r#"{
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[
+                        [-45.0, -45.0],
+                        [45.0, -45.0],
+                        [45.0, 45.0],
+                        [-45.0, 45.0],
+                        [-45.0, -45.0]
+                    ]]
+                }
+            },
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[-60.0, 0.0], [60.0, 0.0]]
+                }
+            },
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [0.0, 0.0]
+                }
+            }
+        ]
+    }"#
+    .parse::<GeoJson>()
+    .expect("inline GeoJSON should parse");
+    source.set_geojson(&geojson);
+
+    let mut style = Style::get_ref(&mut renderer);
+    let source_id = style.add_source(source);
+
+    let mut fill = FillLayer::new("geojson-test-fill", &source_id);
+    fill.set_fill_color(Color::rgba(0.0, 0.8, 0.2, 0.9));
+    fill.set_fill_outline_color(Color::rgb(0.0, 0.2, 0.0));
+    style.add_layer(fill);
+
+    let mut line = LineLayer::new("geojson-test-line", &source_id);
+    line.set_line_color(Color::rgb(0.0, 0.0, 0.0));
+    line.set_line_width(6.0);
+    style.add_layer(line);
+
+    let mut circle = CircleLayer::new("geojson-test-circle", &source_id);
+    circle.set_circle_color(Color::rgb(0.0, 0.2, 1.0));
+    circle.set_circle_radius(12.0);
+    style.add_layer(circle);
+
+    let started = Instant::now();
+    let image = loop {
+        let frame =
+            renderer.render_static(0.0, 0.0, 1.0, 0.0, 0.0).expect("GeoJSON layers should render");
+        if has_non_background_pixel(frame.as_image()) {
+            break frame;
+        }
+        assert!(
+            started.elapsed() < RENDER_TIMEOUT,
+            "GeoJSON layers did not draw pixels within {RENDER_TIMEOUT:?}",
+        );
+    };
+
+    assert_eq!(image.as_image().width(), 128);
+    assert_eq!(image.as_image().height(), 128);
+}


### PR DESCRIPTION
- Add an opaque `GeoJson` wrapper backed by MapLibre Native's GeoJSON representation
  - Add optional `geojson` crate interop
  - Add `GeoJsonSource::set_geojson(&GeoJson)` and remove the temporary point-only API
- Add `CircleLayer`, `LineLayer`, and `FillLayer` wrappers with basic paint property setters
- Map `Color` directly to `mbgl::Color`


## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
- [x] Briefly describe the changes in this PR.
- ~[ ] Link to related issues.~
- [x] Include before/after visuals or gifs if this PR includes visual changes.
- [x] Write tests for all new functionality.
- [x] Document any changes to public APIs.
 ~- [ ] Post benchmark scores.~
 ~- [ ] Add an entry to `CHANGELOG.md` under the `## main` section.~
