### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.4.6...v0.5.0) - 2026-05-19
+
+### Added
+
+- *(style)* add GeoJSON and basic Fill/Line/Circle layer support ([#183](https://github.com/maplibre/maplibre-native-rs/pull/183))
+
 ## [0.4.6](https://github.com/maplibre/maplibre-native-rs/compare/v0.4.5...v0.4.6) - 2026-05-18
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.4.6"
+version = "0.5.0"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -80,7 +80,7 @@ geojson = "1.0.0"
 image = "0.25"
 insta = "1.43"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.4.6" }
+maplibre_native = { path = ".", version = "0.5.0" }
 serde_json = "1.0"
 tar = "0.4.44"
 thiserror = "2.0.16"


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.4.6 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `maplibre_native` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum StyleSource in /tmp/.tmpI8wpjs/maplibre-native-rs/src/renderer/style.rs:116
  enum StyleSource in /tmp/.tmpI8wpjs/maplibre-native-rs/src/renderer/style.rs:116
  enum StyleLayer in /tmp/.tmpI8wpjs/maplibre-native-rs/src/renderer/style.rs:124
  enum StyleLayer in /tmp/.tmpI8wpjs/maplibre-native-rs/src/renderer/style.rs:124

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/inherent_method_missing.ron

Failed in:
  GeoJsonSource::set_point, previously in file /tmp/.tmp1dVpzo/maplibre_native/src/renderer/style/geojson_source.rs:27
  GeoJsonSource::set_point, previously in file /tmp/.tmp1dVpzo/maplibre_native/src/renderer/style/geojson_source.rs:27

--- failure method_receiver_ref_became_mut: method receiver changed from immutable to mutable reference ---

Description:
A method's receiver changed from an immutable reference to a mutable one.
        ref: https://doc.rust-lang.org/reference/items/associated-items.html#methods
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/method_receiver_ref_became_mut.ron

Failed in:
  maplibre_native::style::SymbolLayer::set_icon_image now takes &mut Self, not &Self, in /tmp/.tmpI8wpjs/maplibre-native-rs/src/renderer/style/symbol_layer.rs:25
  maplibre_native::style::SymbolLayer::set_icon_anchor now takes &mut Self, not &Self, in /tmp/.tmpI8wpjs/maplibre-native-rs/src/renderer/style/symbol_layer.rs:30
  maplibre_native::SymbolLayer::set_icon_image now takes &mut Self, not &Self, in /tmp/.tmpI8wpjs/maplibre-native-rs/src/renderer/style/symbol_layer.rs:25
  maplibre_native::SymbolLayer::set_icon_anchor now takes &mut Self, not &Self, in /tmp/.tmpI8wpjs/maplibre-native-rs/src/renderer/style/symbol_layer.rs:30

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct maplibre_native::style::Latitude, previously in file /tmp/.tmp1dVpzo/maplibre_native/src/renderer/style/geojson_source.rs:7
  struct maplibre_native::style::Longitude, previously in file /tmp/.tmp1dVpzo/maplibre_native/src/renderer/style/geojson_source.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.4.6...v0.5.0) - 2026-05-19

### Added

- *(style)* add GeoJSON and basic Fill/Line/Circle layer support ([#183](https://github.com/maplibre/maplibre-native-rs/pull/183))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).