### PR TITLE
feat(renderer): add dedicated run loop mode for multithreaded environments

### DIFF
--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -34,12 +34,24 @@ struct BridgeImage;
 
 class MapRenderer {
 public:
-    explicit MapRenderer(std::unique_ptr<mbgl::HeadlessFrontend> frontendInstance,
-                         std::shared_ptr<MapObserver> mapObserverInstance,
-                         std::unique_ptr<mbgl::Map> mapInstance)
-        : frontend(std::move(frontendInstance)),
-          mapObserverInstance(mapObserverInstance),
-          map(std::move(mapInstance)) {}
+    explicit MapRenderer(mbgl::MapMode mapMode,
+                         mbgl::Size size,
+                         float pixelRatio,
+                         const mbgl::ResourceOptions& resourceOptions,
+                         bool useDedicatedRunLoop)
+        : runLoop(useDedicatedRunLoop ? mbgl::util::RunLoop::Type::New
+                                      : mbgl::util::RunLoop::Type::Default),
+          mapObserverInstance(std::make_shared<MapObserver>()) {
+        frontend = std::make_unique<mbgl::HeadlessFrontend>(size, pixelRatio);
+
+        mbgl::MapOptions mapOptions;
+        mapOptions.withMapMode(mapMode).withSize(size).withPixelRatio(pixelRatio);
+
+        // Set up logging observer for Rust bridge
+        auto logObserver = std::make_unique<mln::bridge::RustLogObserver>();
+        mbgl::Log::setObserver(std::move(logObserver));
+        map = std::make_unique<mbgl::Map>(*frontend, *mapObserverInstance, mapOptions, resourceOptions);
+    }
     ~MapRenderer() {}
 
     std::shared_ptr<MapObserver> observer() {
@@ -150,21 +162,11 @@ inline std::unique_ptr<MapRenderer> MapRenderer_new(
             uint32_t width,
             uint32_t height,
             float pixelRatio,
-            const mbgl::ResourceOptions& resourceOptions
+            const mbgl::ResourceOptions& resourceOptions,
+            bool useDedicatedRunLoop
 ) {
     mbgl::Size size = {width, height};
-    auto mapObserver = std::make_shared<MapObserver>();
-    auto frontend = std::make_unique<mbgl::HeadlessFrontend>(size, pixelRatio);
-
-    mbgl::MapOptions mapOptions;
-    mapOptions.withMapMode(mapMode).withSize(size).withPixelRatio(pixelRatio);
-
-    // Set up logging observer for Rust bridge
-    auto logObserver = std::make_unique<mln::bridge::RustLogObserver>();
-    mbgl::Log::setObserver(std::move(logObserver));
-    auto map = std::make_unique<mbgl::Map>(*frontend, *mapObserver, mapOptions, resourceOptions);
-
-    return std::make_unique<MapRenderer>(std::move(frontend), mapObserver, std::move(map));
+    return std::make_unique<MapRenderer>(mapMode, size, pixelRatio, resourceOptions, useDedicatedRunLoop);
 }
 
 struct BridgeImage {

--- a/src/renderer/bridge.rs
+++ b/src/renderer/bridge.rs
@@ -764,6 +764,7 @@ pub mod ffi {
             height: u32,
             pixelRatio: f32,
             resource_options: &CxxResourceOptions,
+            useDedicatedRunLoop: bool,
         ) -> UniquePtr<MapRenderer>;
         /// Reads the current still image from the renderer.
         fn readStillImage(self: Pin<&mut MapRenderer>) -> UniquePtr<BridgeImage>;

--- a/src/renderer/builder.rs
+++ b/src/renderer/builder.rs
@@ -6,6 +6,26 @@ use crate::ResourceOptions;
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
 
+/// Run loop configuration for an [`ImageRenderer`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RunLoopMode {
+    /// Use a dedicated run loop for this renderer.
+    ///
+    /// This is the default. Suitable for worker-thread pools where each worker
+    /// owns its renderer. The renderer should be constructed and used on the
+    /// same thread.
+    #[default]
+    Dedicated,
+    /// Use MapLibre Native's process-wide default run loop.
+    ///
+    /// Suitable for single-threaded usage where all renderers are constructed and
+    /// used from the same thread. Constructing or using renderers in this mode
+    /// from multiple threads can hang or abort because the default loop is
+    /// process-shared.
+    Shared,
+}
+
 /// Builder for configuring [`ImageRenderer`] instances
 ///
 /// # Examples
@@ -23,10 +43,12 @@ use std::num::NonZeroU32;
 pub struct ImageRendererBuilder {
     /// Image width in pixels
     width: NonZeroU32,
-    /// Image height in pixelsHash
+    /// Image height in pixels
     height: NonZeroU32,
     /// Pixel ratio for high-DPI displays
     pixel_ratio: f32,
+    /// Run loop mode for this renderer
+    run_loop_mode: RunLoopMode,
 
     resource_options: Option<ResourceOptions>,
 }
@@ -38,6 +60,7 @@ impl Default for ImageRendererBuilder {
             width: NonZeroU32::new(512).unwrap(),
             height: NonZeroU32::new(512).unwrap(),
             pixel_ratio: 1.0,
+            run_loop_mode: RunLoopMode::default(),
             resource_options: None,
         }
     }
@@ -79,6 +102,15 @@ impl ImageRendererBuilder {
         self
     }
 
+    /// Sets the run loop mode for the renderer.
+    ///
+    /// Default: [`RunLoopMode::Dedicated`]
+    #[must_use]
+    pub fn with_run_loop_mode(mut self, run_loop_mode: RunLoopMode) -> Self {
+        self.run_loop_mode = run_loop_mode;
+        self
+    }
+
     /// Builds a static image renderer
     #[must_use]
     pub fn build_static_renderer(self) -> ImageRenderer<Static> {
@@ -111,8 +143,63 @@ impl<S> ImageRenderer<S> {
             opts.height.get(),
             opts.pixel_ratio,
             resource_options.as_ref(),
+            opts.run_loop_mode == RunLoopMode::Dedicated,
         );
 
         Self { instance: map, style_specified: false, _marker: PhantomData }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ImageRendererBuilder, RunLoopMode};
+    use std::{num::NonZeroU32, path::PathBuf, thread};
+
+    fn fixture_path(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name)
+    }
+
+    #[test]
+    fn dedicated_run_loop_supports_worker_threads() {
+        let handles = (0..2).map(|_| {
+            thread::spawn(|| {
+                let mut renderer = ImageRendererBuilder::new()
+                    .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
+                    .with_pixel_ratio(1.0)
+                    .build_static_renderer();
+
+                renderer
+                    .load_style_from_path(fixture_path("test-style.json"))
+                    .expect("test style should load");
+                let image = renderer
+                    .render_static(0.0, 0.0, 0.0, 0.0, 0.0)
+                    .expect("dedicated run loop should render");
+
+                assert_eq!(image.as_image().width(), 128);
+                assert_eq!(image.as_image().height(), 128);
+            })
+        });
+
+        for handle in handles {
+            handle.join().expect("render thread should not panic");
+        }
+    }
+
+    #[test]
+    fn shared_run_loop_renders_on_single_thread() {
+        let mut renderer = ImageRendererBuilder::new()
+            .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
+            .with_pixel_ratio(1.0)
+            .with_run_loop_mode(RunLoopMode::Shared)
+            .build_static_renderer();
+
+        renderer
+            .load_style_from_path(fixture_path("test-style.json"))
+            .expect("test style should load");
+        let image =
+            renderer.render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("shared run loop should render");
+
+        assert_eq!(image.as_image().width(), 128);
+        assert_eq!(image.as_image().height(), 128);
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -14,7 +14,7 @@ pub use bridge::{
     map_observer::{MapLoadError, MapObserverCameraChangeMode},
     set_log_thread_enabled, Height, ScreenCoordinate, Size, Width, X, Y,
 };
-pub use builder::ImageRendererBuilder;
+pub use builder::{ImageRendererBuilder, RunLoopMode};
 pub use file_source::{register_file_source_callback, FileSourceRequestCallback, FsResponse};
 pub use image_renderer::{Continuous, Image, ImageRenderer, RenderingError, Static, Tile};
 pub use map_observer::MapObserver;


### PR DESCRIPTION
Add `ImageRendererBuilder::with_run_loop_mode` and `RunLoopMode::{Dedicated, Shared}` to choose between a dedicated run loop per renderer for multithreaded rendering and the existing shared run loop for single-threaded rendering.

- Add `ImageRendererBuilder::with_run_loop_mode` and `RunLoopMode::{Dedicated, Shared}`
- Map `Dedicated` to `mbgl::util::RunLoop::Type::New` and `Shared` to `Type::Default`
- Use `Dedicated` as the default to prevent users from hitting crashes and hangs in multithreaded use
- Keep `Shared` available for single-threaded use with MapLibre Native's default run loop

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
- [x] Briefly describe the changes in this PR.
- ~[ ] Link to related issues~.
- [x] Write tests for all new functionality.
- [x] Document any changes to public APIs.
