### PR TITLE
refactor(renderer)!: drop RunLoopMode in favor of thread-local run loops

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -850,6 +850,10 @@ pub mod ffi {
         type MapObserver; // Created custom map observer
         /// Map renderer for rendering map content.
         type MapRenderer;
+        /// In-flight render request.
+        type RenderRequest;
+        /// Ticks the current thread's MapLibre Native run loop once.
+        fn currentThreadRunLoopTick();
         /// Creates a new map renderer instance.
         #[allow(clippy::too_many_arguments)]
         fn MapRenderer_new(
@@ -858,7 +862,6 @@ pub mod ffi {
             height: u32,
             pixelRatio: f32,
             resource_options: &CxxResourceOptions,
-            useDedicatedRunLoop: bool,
         ) -> UniquePtr<MapRenderer>;
         /// Reads the current still image from the renderer.
         fn readStillImage(self: Pin<&mut MapRenderer>) -> UniquePtr<BridgeImage>;
@@ -870,8 +873,23 @@ pub mod ffi {
         fn bufferLength(self: &BridgeImage) -> usize;
         /// Renders a single frame.
         fn render_once(self: Pin<&mut MapRenderer>);
-        /// Renders continuously.
-        fn render(self: Pin<&mut MapRenderer>) -> UniquePtr<CxxString>;
+        /// Submits a render request without waiting for completion.
+        fn submitRender(
+            self: Pin<&mut MapRenderer>,
+            lat: f64,
+            lon: f64,
+            zoom: f64,
+            bearing: f64,
+            pitch: f64,
+        ) -> UniquePtr<RenderRequest>;
+        /// Returns whether a render request has completed.
+        fn isReady(self: &RenderRequest) -> bool;
+        /// Returns whether a completed render request failed.
+        fn hasError(self: &RenderRequest) -> bool;
+        /// Returns the native error message for a failed render request.
+        fn errorMessage(self: &RenderRequest) -> String;
+        /// Takes the rendered image bytes from a completed render request.
+        fn takeImage(self: Pin<&mut RenderRequest>) -> UniquePtr<CxxString>;
         /// Sets debug visualization flags.
         fn setDebugFlags(self: Pin<&mut MapRenderer>, flags: MapDebugOptions);
         /// Sets the camera position and orientation.

--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/actor/scheduler.hpp>
 #include <mbgl/gfx/headless_frontend.hpp>
 #include <mbgl/style/image.hpp>
 #include <mbgl/style/layer.hpp>
@@ -13,6 +14,7 @@
 #include <mbgl/util/tile_server_options.hpp>
 #include <mbgl/util/size.hpp>
 #include "mbgl/storage/resource_options.hpp"
+#include <cassert>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -28,17 +30,51 @@ namespace bridge {
 constexpr size_t BYTES_PER_PIXEL = 4; // rgba
 
 struct BridgeImage;
+class RenderRequest;
+
+inline mbgl::util::RunLoop& threadRunLoop() {
+    // MapLibre Native's RunLoop is thread-affine. Keep one private loop per
+    // renderer-owning thread and share it between renderers on that thread.
+    thread_local mbgl::util::RunLoop loop(mbgl::util::RunLoop::Type::New);
+    return loop;
+}
+
+inline void bindThreadRunLoop() {
+    mbgl::Scheduler::SetCurrent(&threadRunLoop());
+}
+
+inline void currentThreadRunLoopTick() {
+    // Tick can be driven through a Rust handle without constructing a renderer first.
+    bindThreadRunLoop();
+    threadRunLoop().runOnce();
+}
+
+inline std::unique_ptr<std::string> encodeImage(mbgl::PremultipliedImage image) {
+    auto unpremultipliedImage = mbgl::util::unpremultiply(std::move(image));
+
+    const size_t pixelCount = unpremultipliedImage.size.width * unpremultipliedImage.size.height;
+    std::string data;
+    data.reserve(pixelCount * BYTES_PER_PIXEL);
+
+    uint32_t width = unpremultipliedImage.size.width;
+    uint32_t height = unpremultipliedImage.size.height;
+    data.append(reinterpret_cast<const char*>(&width), sizeof(uint32_t));
+    data.append(reinterpret_cast<const char*>(&height), sizeof(uint32_t));
+
+    const char* pixelData = reinterpret_cast<const char*>(unpremultipliedImage.data.get());
+    data.append(pixelData, pixelCount * BYTES_PER_PIXEL);
+
+    return std::make_unique<std::string>(std::move(data));
+}
 
 class MapRenderer {
 public:
     explicit MapRenderer(mbgl::MapMode mapMode,
                          mbgl::Size size,
                          float pixelRatio,
-                         const mbgl::ResourceOptions& resourceOptions,
-                         bool useDedicatedRunLoop)
-        : runLoop(useDedicatedRunLoop ? mbgl::util::RunLoop::Type::New
-                                      : mbgl::util::RunLoop::Type::Default),
-          mapObserverInstance(std::make_shared<MapObserver>()) {
+                         const mbgl::ResourceOptions& resourceOptions)
+        : mapObserverInstance(std::make_shared<MapObserver>()) {
+        bindThreadRunLoop();
         frontend = std::make_unique<mbgl::HeadlessFrontend>(size, pixelRatio);
 
         mbgl::MapOptions mapOptions;
@@ -103,23 +139,10 @@ public:
         frontend->renderOnce(*map);
     }
 
-    std::unique_ptr<std::string> render() {
-        auto result = frontend->render(*map);
-        auto unpremultipliedImage = mbgl::util::unpremultiply(std::move(result.image));
+    std::unique_ptr<RenderRequest> submitRender(double lat, double lon, double zoom, double bearing, double pitch);
 
-        const size_t pixelCount = unpremultipliedImage.size.width * unpremultipliedImage.size.height;
-        std::string data;
-        data.reserve(pixelCount * BYTES_PER_PIXEL);
-
-        uint32_t width = unpremultipliedImage.size.width;
-        uint32_t height = unpremultipliedImage.size.height;
-        data.append(reinterpret_cast<const char*>(&width), sizeof(uint32_t));
-        data.append(reinterpret_cast<const char*>(&height), sizeof(uint32_t));
-
-        const char* pixelData = reinterpret_cast<const char*>(unpremultipliedImage.data.get());
-        data.append(pixelData, pixelCount * BYTES_PER_PIXEL);
-
-        return std::make_unique<std::string>(std::move(data));
+    std::unique_ptr<std::string> readStillImageBytes() {
+        return encodeImage(frontend->readStillImage());
     }
 
     void setSize(const mbgl::Size& size) {
@@ -149,24 +172,95 @@ public:
 
 
 public:
-    mbgl::util::RunLoop runLoop;
-    // Due to CXX limitations, make all these public and access them from the regular functions below
-    // Hold all objects here, because frontent and the observers are passed by reference to the map
+    // CXX bridge helpers below access these directly. Keep them alive here
+    // because the frontend and observer are passed by reference to the map.
     std::unique_ptr<mbgl::HeadlessFrontend> frontend;
     std::shared_ptr<MapObserver> mapObserverInstance;
     std::unique_ptr<mbgl::Map> map;
 };
+
+class RenderRequest {
+public:
+    struct State {
+        bool ready = false;
+        std::exception_ptr error;
+        std::unique_ptr<std::string> image;
+    };
+
+    RenderRequest()
+        : state(std::make_shared<State>()) {}
+
+    std::shared_ptr<State> getState() const {
+        return state;
+    }
+
+    bool isReady() const {
+        return state->ready;
+    }
+
+    bool hasError() const {
+        return state->error != nullptr;
+    }
+
+    rust::String errorMessage() const {
+        if (!state->error) {
+            return rust::String();
+        }
+
+        try {
+            std::rethrow_exception(state->error);
+        } catch (const std::exception& error) {
+            return rust::String(error.what());
+        } catch (...) {
+            return rust::String("Unknown render error");
+        }
+    }
+
+    std::unique_ptr<std::string> takeImage() {
+        assert(state->ready);
+        assert(!state->error);
+        assert(state->image);
+        assert(!taken);
+        taken = true;
+        return std::move(state->image);
+    }
+
+private:
+    std::shared_ptr<State> state;
+    bool taken = false;
+};
+
+inline std::unique_ptr<RenderRequest> MapRenderer::submitRender(
+        double lat,
+        double lon,
+        double zoom,
+        double bearing,
+        double pitch) {
+    setCamera(lat, lon, zoom, bearing, pitch);
+
+    auto request = std::make_unique<RenderRequest>();
+    auto state = request->getState();
+
+    map->renderStill([this, state](const std::exception_ptr& error) {
+        state->error = error;
+        if (!error) {
+            state->image = readStillImageBytes();
+        }
+        state->ready = true;
+    });
+
+    return request;
+}
 
 inline std::unique_ptr<MapRenderer> MapRenderer_new(
             mbgl::MapMode mapMode,
             uint32_t width,
             uint32_t height,
             float pixelRatio,
-            const mbgl::ResourceOptions& resourceOptions,
-            bool useDedicatedRunLoop
+            const mbgl::ResourceOptions& resourceOptions
 ) {
     mbgl::Size size = {width, height};
-    return std::make_unique<MapRenderer>(mapMode, size, pixelRatio, resourceOptions, useDedicatedRunLoop);
+    return std::make_unique<MapRenderer>(mapMode, size, pixelRatio, resourceOptions);
 }
 
 struct BridgeImage {

--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -54,7 +54,7 @@ inline std::unique_ptr<std::string> encodeImage(mbgl::PremultipliedImage image) 
 
     const size_t pixelCount = unpremultipliedImage.size.width * unpremultipliedImage.size.height;
     std::string data;
-    data.reserve(pixelCount * BYTES_PER_PIXEL);
+    data.reserve(2 * sizeof(uint32_t) + pixelCount * BYTES_PER_PIXEL);
 
     uint32_t width = unpremultipliedImage.size.width;
     uint32_t height = unpremultipliedImage.size.height;
@@ -190,6 +190,15 @@ public:
     RenderRequest()
         : state(std::make_shared<State>()) {}
 
+    ~RenderRequest() {
+        // If the request is dropped before completion, drive the run loop here
+        // while the borrowed renderer is still alive, so MapLibre Native returns to
+        // an idle state before the next submitRender.
+        while (!state->ready) {
+            currentThreadRunLoopTick();
+        }
+    }
+
     std::shared_ptr<State> getState() const {
         return state;
     }
@@ -199,7 +208,7 @@ public:
     }
 
     bool hasError() const {
-        return state->error != nullptr;
+        return static_cast<bool>(state->error);
     }
 
     rust::String errorMessage() const {

--- a/src/renderer/builder.rs
+++ b/src/renderer/builder.rs
@@ -6,27 +6,12 @@ use crate::ResourceOptions;
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
 
-/// Run loop configuration for an [`ImageRenderer`].
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum RunLoopMode {
-    /// Use a dedicated run loop for this renderer.
-    ///
-    /// This is the default. Suitable for worker-thread pools where each worker
-    /// owns its renderer. The renderer should be constructed and used on the
-    /// same thread.
-    #[default]
-    Dedicated,
-    /// Use MapLibre Native's process-wide default run loop.
-    ///
-    /// Suitable for single-threaded usage where all renderers are constructed and
-    /// used from the same thread. Constructing or using renderers in this mode
-    /// from multiple threads can hang or abort because the default loop is
-    /// process-shared.
-    Shared,
-}
-
 /// Builder for configuring [`ImageRenderer`] instances
+///
+/// Each thread that constructs an [`ImageRenderer`] lazily creates one MapLibre
+/// Native run loop. Renderers created on the same thread share that loop, while
+/// renderers created on different threads use independent loops. A renderer must
+/// be constructed and used on the same thread.
 ///
 /// # Examples
 ///
@@ -47,9 +32,6 @@ pub struct ImageRendererBuilder {
     height: NonZeroU32,
     /// Pixel ratio for high-DPI displays
     pixel_ratio: f32,
-    /// Run loop mode for this renderer
-    run_loop_mode: RunLoopMode,
-
     resource_options: Option<ResourceOptions>,
 }
 
@@ -60,7 +42,6 @@ impl Default for ImageRendererBuilder {
             width: NonZeroU32::new(512).unwrap(),
             height: NonZeroU32::new(512).unwrap(),
             pixel_ratio: 1.0,
-            run_loop_mode: RunLoopMode::default(),
             resource_options: None,
         }
     }
@@ -102,15 +83,6 @@ impl ImageRendererBuilder {
         self
     }
 
-    /// Sets the run loop mode for the renderer.
-    ///
-    /// Default: [`RunLoopMode::Dedicated`]
-    #[must_use]
-    pub fn with_run_loop_mode(mut self, run_loop_mode: RunLoopMode) -> Self {
-        self.run_loop_mode = run_loop_mode;
-        self
-    }
-
     /// Builds a static image renderer
     #[must_use]
     pub fn build_static_renderer(self) -> ImageRenderer<Static> {
@@ -143,63 +115,8 @@ impl<S> ImageRenderer<S> {
             opts.height.get(),
             opts.pixel_ratio,
             resource_options.as_ref(),
-            opts.run_loop_mode == RunLoopMode::Dedicated,
         );
 
-        Self { instance: map, style_specified: false, _marker: PhantomData }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{ImageRendererBuilder, RunLoopMode};
-    use std::{num::NonZeroU32, path::PathBuf, thread};
-
-    fn fixture_path(name: &str) -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name)
-    }
-
-    #[test]
-    fn dedicated_run_loop_supports_worker_threads() {
-        let handles = (0..2).map(|_| {
-            thread::spawn(|| {
-                let mut renderer = ImageRendererBuilder::new()
-                    .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
-                    .with_pixel_ratio(1.0)
-                    .build_static_renderer();
-
-                renderer
-                    .load_style_from_path(fixture_path("test-style.json"))
-                    .expect("test style should load");
-                let image = renderer
-                    .render_static(0.0, 0.0, 0.0, 0.0, 0.0)
-                    .expect("dedicated run loop should render");
-
-                assert_eq!(image.as_image().width(), 128);
-                assert_eq!(image.as_image().height(), 128);
-            })
-        });
-
-        for handle in handles {
-            handle.join().expect("render thread should not panic");
-        }
-    }
-
-    #[test]
-    fn shared_run_loop_renders_on_single_thread() {
-        let mut renderer = ImageRendererBuilder::new()
-            .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
-            .with_pixel_ratio(1.0)
-            .with_run_loop_mode(RunLoopMode::Shared)
-            .build_static_renderer();
-
-        renderer
-            .load_style_from_path(fixture_path("test-style.json"))
-            .expect("test style should load");
-        let image =
-            renderer.render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("shared run loop should render");
-
-        assert_eq!(image.as_image().width(), 128);
-        assert_eq!(image.as_image().height(), 128);
+        Self { instance: map, style_specified: false, _marker: PhantomData, _not_send: PhantomData }
     }
 }

--- a/src/renderer/image_renderer.rs
+++ b/src/renderer/image_renderer.rs
@@ -2,6 +2,7 @@ use super::MapObserver;
 use crate::bridge::ffi;
 use crate::bridge::ffi::BridgeImage;
 use crate::renderer::MapDebugOptions;
+use crate::RunLoopHandle;
 use crate::{Latitude, Longitude, ScreenCoordinate, Size};
 use cxx::UniquePtr;
 use image::{ImageBuffer, Rgba};
@@ -75,7 +76,68 @@ pub struct Continuous;
 pub struct ImageRenderer<S> {
     pub(crate) instance: UniquePtr<ffi::MapRenderer>,
     pub(crate) _marker: PhantomData<S>,
+    pub(crate) _not_send: PhantomData<*mut ()>,
     pub(crate) style_specified: bool,
+}
+
+/// In-flight render request.
+///
+/// Tick the current thread's run loop via [`RunLoopHandle::tick`] until
+/// [`is_ready`](Self::is_ready) returns `true`, then call
+/// [`finish`](Self::finish).
+#[must_use = "render requests must be finished or waited on to complete the render"]
+pub struct RenderRequest<'a, S> {
+    instance: UniquePtr<ffi::RenderRequest>,
+    _renderer: PhantomData<&'a mut ImageRenderer<S>>,
+    _not_send: PhantomData<*mut ()>,
+}
+
+impl<S> Debug for RenderRequest<'_, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RenderRequest").field("ready", &self.is_ready()).finish_non_exhaustive()
+    }
+}
+
+impl<S> RenderRequest<'_, S> {
+    /// Returns whether the render request has completed.
+    #[must_use]
+    pub fn is_ready(&self) -> bool {
+        self.instance.isReady()
+    }
+
+    /// Returns the rendered image.
+    ///
+    /// # Panics
+    ///
+    /// If [`is_ready`](Self::is_ready) returns `false`.
+    ///
+    /// # Errors
+    ///
+    /// If the underlying render failed or produced invalid image data.
+    pub fn finish(mut self) -> Result<Image, RenderingError> {
+        assert!(self.is_ready(), "render request is not ready");
+
+        if self.instance.hasError() {
+            return Err(RenderingError::Native(self.instance.errorMessage()));
+        }
+
+        let data = self.instance.pin_mut().takeImage();
+        let bytes = data.as_bytes();
+        Image::from_raw(bytes).ok_or(RenderingError::InvalidImageData)
+    }
+
+    /// Ticks the run loop until ready, then calls [`finish`](Self::finish).
+    ///
+    /// # Errors
+    ///
+    /// If the underlying render failed or produced invalid image data.
+    pub fn wait(self) -> Result<Image, RenderingError> {
+        let run_loop = RunLoopHandle::current();
+        while !self.is_ready() {
+            run_loop.tick();
+        }
+        self.finish()
+    }
 }
 
 impl<S> Debug for ImageRenderer<S> {
@@ -138,8 +200,7 @@ impl ImageRenderer<Static> {
     /// Render the map as a static [`Image`] where the camera can be freely controlled.
     ///
     /// # Errors
-    /// Returns an error if
-    /// - the style has not been specified via either [`load_style_from_path`](Self::load_style_from_path) or [`load_style_from_url`](Self::load_style_from_url).
+    /// If no style has been loaded.
     pub fn render_static(
         &mut self,
         lat: f64,
@@ -148,16 +209,27 @@ impl ImageRenderer<Static> {
         bearing: f64,
         pitch: f64,
     ) -> Result<Image, RenderingError> {
+        self.submit_render_static(lat, lon, zoom, bearing, pitch)?.wait()
+    }
+
+    /// Submits a static render request. See [`RenderRequest`].
+    ///
+    /// # Errors
+    /// If no style has been loaded.
+    pub fn submit_render_static(
+        &mut self,
+        lat: f64,
+        lon: f64,
+        zoom: f64,
+        bearing: f64,
+        pitch: f64,
+    ) -> Result<RenderRequest<'_, Static>, RenderingError> {
         if !self.style_specified {
             return Err(RenderingError::StyleNotSpecified);
         }
 
-        self.instance.pin_mut().setCamera(lat, lon, zoom, bearing, pitch);
-        let data = self.instance.pin_mut().render();
-        let bytes = data.as_bytes();
-
-        let image = Image::from_raw(bytes).ok_or(RenderingError::InvalidImageData)?;
-        Ok(image)
+        let request = self.instance.pin_mut().submitRender(lat, lon, zoom, bearing, pitch);
+        Ok(RenderRequest { instance: request, _renderer: PhantomData, _not_send: PhantomData })
     }
 }
 
@@ -165,20 +237,28 @@ impl ImageRenderer<Tile> {
     /// Render a top-down tile of the map as a static [`Image`].
     ///
     /// # Errors
-    /// Returns an error if
-    /// - the style has not been specified via either [`load_style_from_path`](Self::load_style_from_path) or [`load_style_from_url`](Self::load_style_from_url).
+    /// If no style has been loaded.
     pub fn render_tile(&mut self, zoom: u8, x: u32, y: u32) -> Result<Image, RenderingError> {
+        self.submit_render_tile(zoom, x, y)?.wait()
+    }
+
+    /// Submits a tile render request. See [`RenderRequest`].
+    ///
+    /// # Errors
+    /// If no style has been loaded.
+    pub fn submit_render_tile(
+        &mut self,
+        zoom: u8,
+        x: u32,
+        y: u32,
+    ) -> Result<RenderRequest<'_, Tile>, RenderingError> {
         if !self.style_specified {
             return Err(RenderingError::StyleNotSpecified);
         }
 
         let (lat, lon) = coords_to_lat_lon(f64::from(zoom), x, y);
-        self.instance.pin_mut().setCamera(lat.0, lon.0, f64::from(zoom), 0.0, 0.0);
-
-        let data = self.instance.pin_mut().render();
-        let bytes = data.as_bytes();
-        let image = Image::from_raw(bytes).ok_or(RenderingError::InvalidImageData)?;
-        Ok(image)
+        let request = self.instance.pin_mut().submitRender(lat.0, lon.0, f64::from(zoom), 0.0, 0.0);
+        Ok(RenderRequest { instance: request, _renderer: PhantomData, _not_send: PhantomData })
     }
 }
 
@@ -265,11 +345,14 @@ fn coords_to_lat_lon(zoom: f64, x: u32, y: u32) -> (Latitude, Longitude) {
 #[derive(thiserror::Error, Debug)]
 pub enum RenderingError {
     /// Style must be specified before rendering can occur.
-    #[error("Style must be specified to render a tile")]
+    #[error("Style must be specified before rendering")]
     StyleNotSpecified,
     /// The renderer returned invalid or corrupted image data.
     #[error("Invalid image data received from renderer")]
     InvalidImageData,
+    /// MapLibre Native returned a rendering error.
+    #[error("Native rendering error: {0}")]
+    Native(String),
 }
 
 #[cfg(test)]

--- a/src/renderer/image_renderer.rs
+++ b/src/renderer/image_renderer.rs
@@ -76,6 +76,7 @@ pub struct Continuous;
 pub struct ImageRenderer<S> {
     pub(crate) instance: UniquePtr<ffi::MapRenderer>,
     pub(crate) _marker: PhantomData<S>,
+    // Makes this type !Send and !Sync: the underlying run loop is thread-affine.
     pub(crate) _not_send: PhantomData<*mut ()>,
     pub(crate) style_specified: bool,
 }
@@ -85,10 +86,17 @@ pub struct ImageRenderer<S> {
 /// Tick the current thread's run loop via [`RunLoopHandle::tick`] until
 /// [`is_ready`](Self::is_ready) returns `true`, then call
 /// [`finish`](Self::finish).
+///
+/// This is intentionally a runtime-agnostic primitive rather than a
+/// [`std::future::Future`]. No async runtime drives MapLibre Native's libuv
+/// run loop, so the caller advances it explicitly via
+/// [`RunLoopHandle::tick`]; a bare `Future` would never make progress under
+/// e.g. tokio without an explicit ticker.
 #[must_use = "render requests must be finished or waited on to complete the render"]
 pub struct RenderRequest<'a, S> {
     instance: UniquePtr<ffi::RenderRequest>,
     _renderer: PhantomData<&'a mut ImageRenderer<S>>,
+    // Makes this type !Send and !Sync: the underlying run loop is thread-affine.
     _not_send: PhantomData<*mut ()>,
 }
 
@@ -126,7 +134,8 @@ impl<S> RenderRequest<'_, S> {
         Image::from_raw(bytes).ok_or(RenderingError::InvalidImageData)
     }
 
-    /// Ticks the run loop until ready, then calls [`finish`](Self::finish).
+    /// Blocks on the current thread by ticking the run loop until ready, then
+    /// calls [`finish`](Self::finish).
     ///
     /// # Errors
     ///
@@ -212,7 +221,11 @@ impl ImageRenderer<Static> {
         self.submit_render_static(lat, lon, zoom, bearing, pitch)?.wait()
     }
 
-    /// Submits a static render request. See [`RenderRequest`].
+    /// Submits a static render request without blocking.
+    ///
+    /// Use this when driving one or more requests manually with
+    /// [`RunLoopHandle::tick`]. Use [`render_static`](Self::render_static) for
+    /// the blocking convenience API.
     ///
     /// # Errors
     /// If no style has been loaded.
@@ -242,7 +255,11 @@ impl ImageRenderer<Tile> {
         self.submit_render_tile(zoom, x, y)?.wait()
     }
 
-    /// Submits a tile render request. See [`RenderRequest`].
+    /// Submits a tile render request without blocking.
+    ///
+    /// Use this when driving one or more requests manually with
+    /// [`RunLoopHandle::tick`]. Use [`render_tile`](Self::render_tile) for the
+    /// blocking convenience API.
     ///
     /// # Errors
     /// If no style has been loaded.

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -4,18 +4,23 @@ pub mod file_source;
 mod image_renderer;
 mod map_observer;
 mod resource_options;
+mod run_loop;
 pub mod tile_server_options;
+
 pub use crate::bridge::file_source::{FsErrorReason, ResourceKind};
 pub use crate::bridge::{
     ffi::{MapDebugOptions, MapMode},
     map_observer::{MapLoadError, MapObserverCameraChangeMode},
     set_log_thread_enabled, Height, ScreenCoordinate, Size, Width, X, Y,
 };
-pub use builder::{ImageRendererBuilder, RunLoopMode};
+pub use builder::ImageRendererBuilder;
 pub use file_source::{register_file_source_callback, FileSourceRequestCallback, FsResponse};
-pub use image_renderer::{Continuous, Image, ImageRenderer, RenderingError, Static, Tile};
+pub use image_renderer::{
+    Continuous, Image, ImageRenderer, RenderRequest, RenderingError, Static, Tile,
+};
 pub use map_observer::MapObserver;
 pub use resource_options::ResourceOptions;
+pub use run_loop::RunLoopHandle;
 
 /// Latitude coordinate value.
 #[derive(Debug, Clone, Copy)]

--- a/src/renderer/run_loop.rs
+++ b/src/renderer/run_loop.rs
@@ -1,0 +1,28 @@
+//! MapLibre Native run loop handle.
+
+use crate::bridge::ffi;
+use std::marker::PhantomData;
+
+/// Handle to the current thread's MapLibre Native run loop.
+///
+/// Use [`tick`](Self::tick) to advance pending render requests on this thread.
+#[derive(Debug)]
+pub struct RunLoopHandle {
+    // Makes this handle !Send and !Sync: MapLibre Native run loops are thread-affine.
+    // This marker keeps the handle on the thread that created it.
+    _not_send: PhantomData<*mut ()>,
+}
+
+impl RunLoopHandle {
+    /// Returns a handle to the current thread's MapLibre Native run loop.
+    #[must_use]
+    pub fn current() -> Self {
+        Self { _not_send: PhantomData }
+    }
+
+    /// Ticks the current thread's run loop once.
+    #[allow(clippy::unused_self, reason = "method syntax ties ticking to a run-loop handle")]
+    pub fn tick(&self) {
+        ffi::currentThreadRunLoopTick();
+    }
+}

--- a/tests/image_renderer.rs
+++ b/tests/image_renderer.rs
@@ -1,10 +1,29 @@
 //! Integration tests for image renderer request and run loop behavior.
 
 use maplibre_native::{ImageRendererBuilder, RunLoopHandle};
-use std::{num::NonZeroU32, path::PathBuf, thread};
+use std::{
+    num::NonZeroU32,
+    path::PathBuf,
+    thread,
+    time::{Duration, Instant},
+};
+
+const RENDER_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn fixture_path(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name)
+}
+
+fn tick_until_ready(mut ready: impl FnMut() -> bool) {
+    let run_loop = RunLoopHandle::current();
+    let deadline = Instant::now() + RENDER_TIMEOUT;
+    while !ready() {
+        assert!(
+            Instant::now() < deadline,
+            "render request did not complete within {RENDER_TIMEOUT:?}"
+        );
+        run_loop.tick();
+    }
 }
 
 #[test]
@@ -47,15 +66,12 @@ fn multiple_renderers_render_on_single_thread() {
     first.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
     second.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
 
-    let run_loop = RunLoopHandle::current();
     let first_request =
         first.submit_render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("first render should submit");
     let second_request =
         second.submit_render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("second render should submit");
 
-    while !first_request.is_ready() || !second_request.is_ready() {
-        run_loop.tick();
-    }
+    tick_until_ready(|| first_request.is_ready() && second_request.is_ready());
 
     let first_image = first_request.finish().expect("first renderer should render");
     let second_image = second_request.finish().expect("second renderer should render");
@@ -75,14 +91,26 @@ fn tile_render_request_renders() {
 
     renderer.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
 
-    let run_loop = RunLoopHandle::current();
     let request = renderer.submit_render_tile(0, 0, 0).expect("tile render should submit");
 
-    while !request.is_ready() {
-        run_loop.tick();
-    }
+    tick_until_ready(|| request.is_ready());
 
     let image = request.finish().expect("tile renderer should render");
     assert_eq!(image.as_image().width(), 128);
     assert_eq!(image.as_image().height(), 128);
+}
+
+#[test]
+fn dropping_render_request_before_renderer_is_safe() {
+    let mut renderer = ImageRendererBuilder::new()
+        .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
+        .with_pixel_ratio(1.0)
+        .build_static_renderer();
+
+    renderer.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
+
+    let request =
+        renderer.submit_render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("render should submit");
+    drop(request);
+    drop(renderer);
 }

--- a/tests/image_renderer.rs
+++ b/tests/image_renderer.rs
@@ -1,0 +1,88 @@
+//! Integration tests for image renderer request and run loop behavior.
+
+use maplibre_native::{ImageRendererBuilder, RunLoopHandle};
+use std::{num::NonZeroU32, path::PathBuf, thread};
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name)
+}
+
+#[test]
+fn thread_run_loop_supports_worker_threads() {
+    let handles = (0..2).map(|_| {
+        thread::spawn(|| {
+            let mut renderer = ImageRendererBuilder::new()
+                .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
+                .with_pixel_ratio(1.0)
+                .build_static_renderer();
+
+            renderer
+                .load_style_from_path(fixture_path("test-style.json"))
+                .expect("test style should load");
+            let image = renderer
+                .render_static(0.0, 0.0, 0.0, 0.0, 0.0)
+                .expect("thread run loop should render");
+
+            assert_eq!(image.as_image().width(), 128);
+            assert_eq!(image.as_image().height(), 128);
+        })
+    });
+
+    for handle in handles {
+        handle.join().expect("render thread should not panic");
+    }
+}
+
+#[test]
+fn multiple_renderers_render_on_single_thread() {
+    let mut first = ImageRendererBuilder::new()
+        .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
+        .with_pixel_ratio(1.0)
+        .build_static_renderer();
+    let mut second = ImageRendererBuilder::new()
+        .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
+        .with_pixel_ratio(1.0)
+        .build_static_renderer();
+
+    first.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
+    second.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
+
+    let run_loop = RunLoopHandle::current();
+    let first_request =
+        first.submit_render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("first render should submit");
+    let second_request =
+        second.submit_render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("second render should submit");
+
+    while !first_request.is_ready() || !second_request.is_ready() {
+        run_loop.tick();
+    }
+
+    let first_image = first_request.finish().expect("first renderer should render");
+    let second_image = second_request.finish().expect("second renderer should render");
+
+    assert_eq!(first_image.as_image().width(), 128);
+    assert_eq!(first_image.as_image().height(), 128);
+    assert_eq!(second_image.as_image().width(), 128);
+    assert_eq!(second_image.as_image().height(), 128);
+}
+
+#[test]
+fn tile_render_request_renders() {
+    let mut renderer = ImageRendererBuilder::new()
+        .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
+        .with_pixel_ratio(1.0)
+        .build_tile_renderer();
+
+    renderer.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
+
+    let run_loop = RunLoopHandle::current();
+    let request = renderer.submit_render_tile(0, 0, 0).expect("tile render should submit");
+
+    while !request.is_ready() {
+        run_loop.tick();
+    }
+
+    let image = request.finish().expect("tile renderer should render");
+    assert_eq!(image.as_image().width(), 128);
+    assert_eq!(image.as_image().height(), 128);
+}

--- a/tests/image_renderer.rs
+++ b/tests/image_renderer.rs
@@ -71,6 +71,7 @@ fn multiple_renderers_render_on_single_thread() {
     let second_request =
         second.submit_render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("second render should submit");
 
+    // Both requests are driven from the same thread-local run loop.
     tick_until_ready(|| first_request.is_ready() && second_request.is_ready());
 
     let first_image = first_request.finish().expect("first renderer should render");

--- a/tests/style_geojson_layers.rs
+++ b/tests/style_geojson_layers.rs
@@ -4,21 +4,12 @@ use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use std::sync::{Mutex, MutexGuard};
-
 use maplibre_native::{
     CircleLayer, Color, FillLayer, GeoJson, GeoJsonSource, Image, ImageRenderer,
     ImageRendererBuilder, LineCap, LineJoin, LineLayer, Static, Style,
 };
 
 const RENDER_TIMEOUT: Duration = Duration::from_secs(5);
-
-// TODO: Remove this once rendering can be started safely from multiple Rust threads.
-static RENDER_TEST_LOCK: Mutex<()> = Mutex::new(());
-
-fn render_test_lock() -> MutexGuard<'static, ()> {
-    RENDER_TEST_LOCK.lock().expect("render test lock should not be poisoned")
-}
 
 fn fixture_path(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name)
@@ -104,7 +95,6 @@ where
 
 #[test]
 fn geojson_source_renders_circle_line_and_fill_layers() {
-    let _guard = render_test_lock();
     let mut renderer = renderer();
 
     let mut source = GeoJsonSource::new("geojson-test-source");
@@ -142,7 +132,6 @@ fn geojson_source_renders_circle_line_and_fill_layers() {
 
 #[test]
 fn layer_management_methods_smoke_test() {
-    let _guard = render_test_lock();
     let mut renderer = renderer();
     let mut style = Style::get_ref(&mut renderer);
 


### PR DESCRIPTION
Follow-up to #188

This PR simplifies run-loop management by removing the explicit run loop mode selection (introduced by #188) and using an automatically managed thread-local run loop instead.

- Removes the `Dedicated` vs `Shared` choice from the API
- Gives each thread its own MapLibre Native run loop automatically
- Supports both thread-pool rendering and single-threaded async-style rendering without extra configuration
- Adds render request APIs so single-threaded code can submit renders and drive completion by ticking the current thread's run loop

Breaking: removes `RunLoopMode` and `ImageRendererBuilder::with_run_loop_mode`.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
- [x] Briefly describe the changes in this PR.
- [x] Write tests for all new functionality.
- [x] Document any changes to public APIs.