### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.5.0...v0.6.0) - 2026-05-23
+
+### Other
+
+- *(renderer)* [**breaking**] drop RunLoopMode in favor of thread-local run loops ([#190](https://github.com/maplibre/maplibre-native-rs/pull/190))
+
 ## [0.5.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.4.6...v0.5.0) - 2026-05-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.5.0"
+version = "0.6.0"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -80,7 +80,7 @@ geojson = "1.0.0"
 image = "0.25"
 insta = "1.43"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.5.0" }
+maplibre_native = { path = ".", version = "0.6.0" }
 serde_json = "1.0"
 tar = "0.4.44"
 thiserror = "2.0.16"


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `maplibre_native` breaking changes

```text
--- failure enum_discriminants_undefined_non_unit_variant: enum's variants no longer have defined discriminants due to non-unit variant ---

Description:
An enum's variants no longer have well-defined discriminant values due to a tuple or struct variant in the enum. This breaks downstream code that accesses discriminants via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_discriminants_undefined_non_unit_variant.ron

Failed in:
  enum RenderingError in /tmp/.tmp4FiMjz/maplibre-native-rs/src/renderer/image_renderer.rs:363

--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum GeoJsonError in /tmp/.tmp4FiMjz/maplibre-native-rs/src/style/geojson.rs:10

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_missing.ron

Failed in:
  enum maplibre_native::style::StyleSource, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:116
  enum maplibre_native::StyleSource, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:116
  enum maplibre_native::style::StyleLayer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:124
  enum maplibre_native::StyleLayer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:124
  enum maplibre_native::style::GeoJsonError, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style/geojson.rs:9

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant RenderingError:Native in /tmp/.tmp4FiMjz/maplibre-native-rs/src/renderer/image_renderer.rs:372

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_missing.ron

Failed in:
  function maplibre_native::layers::setIconAnchor, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:276
  function maplibre_native::layers::setCircleColor, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:241
  function maplibre_native::layers::create_fill_layer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:249
  function maplibre_native::layers::setFillOutlineColor, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:255
  function maplibre_native::layers::setLineOpacity, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:263
  function maplibre_native::layers::setIconImage, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:274
  function maplibre_native::layers::create_circle_layer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:236
  function maplibre_native::layers::setCircleRadius, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:245
  function maplibre_native::layers::setFillOpacity, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:253
  function maplibre_native::layers::setLineColor, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:261
  function maplibre_native::layers::create_symbol_layer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:269
  function maplibre_native::layers::setCircleOpacity, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:243
  function maplibre_native::layers::setFillColor, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:251
  function maplibre_native::layers::create_line_layer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:259
  function maplibre_native::layers::setLineWidth, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:265

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  maplibre_native::SymbolLayer::new takes 0 generic types instead of 1, in /tmp/.tmp4FiMjz/maplibre-native-rs/src/style/layers/symbol.rs:64
  maplibre_native::SymbolLayer::set_icon_image takes 0 generic types instead of 1, in /tmp/.tmp4FiMjz/maplibre-native-rs/src/style/layers/symbol.rs:76
  maplibre_native::FillLayer::new takes 0 generic types instead of 1, in /tmp/.tmp4FiMjz/maplibre-native-rs/src/style/layers/fill.rs:16
  maplibre_native::CircleLayer::new takes 0 generic types instead of 1, in /tmp/.tmp4FiMjz/maplibre-native-rs/src/style/layers/circle.rs:16
  maplibre_native::LineLayer::new takes 0 generic types instead of 1, in /tmp/.tmp4FiMjz/maplibre-native-rs/src/style/layers/line.rs:74

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/module_missing.ron

Failed in:
  mod maplibre_native::style, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:1
  mod maplibre_native::layers, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:175

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct maplibre_native::style::GeoJson, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style/geojson.rs:27
  struct maplibre_native::layers::SymbolAnchorType, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:179
  struct maplibre_native::style::SymbolLayer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style/symbol_layer.rs:8
  struct maplibre_native::style::FillLayer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style/fill_layer.rs:8
  struct maplibre_native::style::SourceId, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:79
  struct maplibre_native::style::CircleLayer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style/circle_layer.rs:8
  struct maplibre_native::layers::SymbolLayer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:216
  struct maplibre_native::layers::CircleLayer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:209
  struct maplibre_native::style::LineLayer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style/line_layer.rs:8
  struct maplibre_native::style::Style, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:137
  struct maplibre_native::layers::Color, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:28
  struct maplibre_native::style::Color, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:28
  struct maplibre_native::layers::FillLayer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:211
  struct maplibre_native::layers::LineLayer, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/bridge.rs:213
  struct maplibre_native::style::ImageId, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:97
  struct maplibre_native::style::GeoJsonSource, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style/geojson_source.rs:8

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/trait_missing.ron

Failed in:
  trait maplibre_native::style::StyleImageRef, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:72
  trait maplibre_native::style::StyleSourceRef, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:66
  trait maplibre_native::StyleSourceRef, previously in file /tmp/.tmpprYnJP/maplibre_native/src/renderer/style.rs:66
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.5.0...v0.6.0) - 2026-05-23

### Other

- *(renderer)* [**breaking**] drop RunLoopMode in favor of thread-local run loops ([#190](https://github.com/maplibre/maplibre-native-rs/pull/190))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).