### PR TITLE
feat(renderer): add load_style_from_json()

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -907,6 +907,8 @@ pub mod ffi {
         fn scaleBy(self: Pin<&mut MapRenderer>, scale: f64, pos: &ScreenCoordinate);
         /// Loads a style from a URL.
         fn style_load_from_url(self: Pin<&mut MapRenderer>, url: &str);
+        /// Loads a style from a JSON string.
+        fn style_load_from_json(self: Pin<&mut MapRenderer>, json: &str);
         /// Sets the renderer size.
         fn setSize(self: Pin<&mut MapRenderer>, size: &Size);
         /// Gets the map observer.

--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -129,6 +129,10 @@ public:
         map->getStyle().loadURL((std::string)styleUrl);
     }
 
+    void style_load_from_json(const rust::Str styleJson) {
+        map->getStyle().loadJSON((std::string)styleJson);
+    }
+
     std::unique_ptr<BridgeImage> readStillImage() {
         auto image = frontend->readStillImage();
         auto unpremultipliedImage = mbgl::util::unpremultiply(std::move(image));

--- a/src/renderer/image_renderer.rs
+++ b/src/renderer/image_renderer.rs
@@ -165,6 +165,13 @@ impl<S> ImageRenderer<S> {
         self
     }
 
+    /// Loads the style from a JSON string.
+    pub fn load_style_from_json(&mut self, json: impl AsRef<str>) -> &mut Self {
+        self.style_specified = true;
+        self.instance.pin_mut().style_load_from_json(json.as_ref());
+        self
+    }
+
     /// Load the style from the specified path.
     ///
     /// The style will be loaded from the path, but won't be refreshed automatically if the file changes

--- a/tests/image_renderer.rs
+++ b/tests/image_renderer.rs
@@ -84,6 +84,20 @@ fn multiple_renderers_render_on_single_thread() {
 }
 
 #[test]
+fn load_style_from_json_renders() {
+    let mut renderer = ImageRendererBuilder::new()
+        .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
+        .with_pixel_ratio(1.0)
+        .build_static_renderer();
+
+    renderer.load_style_from_json(include_str!("fixtures/test-style.json"));
+
+    let image = renderer.render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("JSON style should render");
+    assert_eq!(image.as_image().width(), 128);
+    assert_eq!(image.as_image().height(), 128);
+}
+
+#[test]
 fn tile_render_request_renders() {
     let mut renderer = ImageRendererBuilder::new()
         .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())

--- a/tests/image_renderer.rs
+++ b/tests/image_renderer.rs
@@ -92,7 +92,12 @@ fn load_style_from_json_renders() {
 
     renderer.load_style_from_json(include_str!("fixtures/test-style.json"));
 
-    let image = renderer.render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("JSON style should render");
+    let request = renderer
+        .submit_render_static(0.0, 0.0, 0.0, 0.0, 0.0)
+        .expect("JSON style render should submit");
+    tick_until_ready(|| request.is_ready());
+
+    let image = request.finish().expect("JSON style should render");
     assert_eq!(image.as_image().width(), 128);
     assert_eq!(image.as_image().height(), 128);
 }


### PR DESCRIPTION
Provide a Rust binding for C++ `Style::loadJSON`, alongside the existing `Style::loadURL` binding.
