### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.6.0...v0.6.1) - 2026-05-26
+
+### Fixed
+
+- *(renderer)* expose map_observer() for all renderer modes ([#198](https://github.com/maplibre/maplibre-native-rs/pull/198))
+
 ## [0.6.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.5.0...v0.6.0) - 2026-05-23
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.6.0"
+version = "0.6.1"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -80,7 +80,7 @@ geojson = "1.0.0"
 image = "0.25"
 insta = "1.43"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.6.0" }
+maplibre_native = { path = ".", version = "0.6.1" }
 serde_json = "1.0"
 tar = "0.4.44"
 thiserror = "2.0.16"


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.6.0...v0.6.1) - 2026-05-26

### Fixed

- *(renderer)* expose map_observer() for all renderer modes ([#198](https://github.com/maplibre/maplibre-native-rs/pull/198))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).