### PR TITLE
feat(renderer)!: add camera APIs and bounds-fit rendering capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,9 @@ let mut renderer = ImageRendererBuilder::new()
                       .with_size(NonZeroU32::new(512).unwrap(),NonZeroU32::new(512).unwrap())
                       .build_static_renderer();
 renderer.load_style_from_url(&"https://demotiles.maplibre.org/style.json".parse().unwrap());
-let camera = CameraUpdate {
-    center: Some(LatLng { lat: 0.0, lng: 0.0 }),
-    zoom: Some(0.0),
-    ..Default::default()
-};
+let camera = CameraUpdate::new()
+    .center(LatLng { lat: 0.0, lng: 0.0 })
+    .zoom(0.0);
 let image: Image = renderer.render_static(&camera).unwrap();
 
 // Access the underlying ImageBuffer for all operations

--- a/README.md
+++ b/README.md
@@ -32,14 +32,19 @@ We also support the following other features:
 At its core, we work as follows:
 
 ```rust
-use maplibre_native::{ImageRendererBuilder, Image};
+use maplibre_native::{CameraUpdate, ImageRendererBuilder, Image, LatLng};
 use std::num::NonZeroU32;
 
 let mut renderer = ImageRendererBuilder::new()
                       .with_size(NonZeroU32::new(512).unwrap(),NonZeroU32::new(512).unwrap())
                       .build_static_renderer();
 renderer.load_style_from_url(&"https://demotiles.maplibre.org/style.json".parse().unwrap());
-let image: Image = renderer.render_static(0.0, 0.0, 0.0, 0.0, 0.0).unwrap();
+let camera = CameraUpdate {
+    center: Some(LatLng { lat: 0.0, lng: 0.0 }),
+    zoom: Some(0.0),
+    ..Default::default()
+};
+let image: Image = renderer.render_static(&camera).unwrap();
 
 // Access the underlying ImageBuffer for all operations
 let img_buffer = image.as_image();

--- a/examples/render/src/main.rs
+++ b/examples/render/src/main.rs
@@ -217,13 +217,13 @@ impl Renderer {
     fn render(&mut self) -> Image {
         match self {
             Renderer::Static { map, lat, lon, zoom, bearing, pitch } => map
-                .render_static(&CameraUpdate {
-                    center: Some(LatLng { lat: *lat, lng: *lon }),
-                    zoom: Some(*zoom),
-                    bearing: Some(*bearing),
-                    pitch: Some(*pitch),
-                    ..Default::default()
-                })
+                .render_static(
+                    &CameraUpdate::new()
+                        .center(LatLng { lat: *lat, lng: *lon })
+                        .zoom(*zoom)
+                        .bearing(*bearing)
+                        .pitch(*pitch),
+                )
                 .expect("could not render image"),
             Renderer::Tiled { map, x, y, z } => {
                 map.render_tile(*z, *x, *y).expect("could not render image")

--- a/examples/render/src/main.rs
+++ b/examples/render/src/main.rs
@@ -13,7 +13,8 @@ use std::time::Instant;
 use clap::Parser;
 use env_logger::Env;
 use maplibre_native::{
-    Image, ImageRenderer, ImageRendererBuilder, MapDebugOptions, ResourceOptions, Static, Tile,
+    CameraUpdate, Image, ImageRenderer, ImageRendererBuilder, LatLng, MapDebugOptions,
+    ResourceOptions, Static, Tile,
 };
 
 /// Command-line tool to render a map via [`mapLibre-native`](https://github.com/maplibre/maplibre-native)
@@ -216,7 +217,13 @@ impl Renderer {
     fn render(&mut self) -> Image {
         match self {
             Renderer::Static { map, lat, lon, zoom, bearing, pitch } => map
-                .render_static(*lat, *lon, *zoom, *bearing, *pitch)
+                .render_static(&CameraUpdate {
+                    center: Some(LatLng { lat: *lat, lng: *lon }),
+                    zoom: Some(*zoom),
+                    bearing: Some(*bearing),
+                    pitch: Some(*pitch),
+                    ..Default::default()
+                })
                 .expect("could not render image"),
             Renderer::Tiled { map, x, y, z } => {
                 map.render_tile(*z, *x, *y).expect("could not render image")

--- a/examples/slint/src/maplibre.rs
+++ b/examples/slint/src/maplibre.rs
@@ -7,8 +7,8 @@ pub use headless::MapLibre;
 pub use headless::create_map;
 use image::ImageReader;
 use maplibre_native::{
-    CircleLayer, Color, FillLayer, GeoJson, GeoJsonSource, Height, LineLayer, ScreenCoordinate,
-    Style, SymbolAnchor, SymbolLayer, Width, X, Y,
+    CircleLayer, Color, FillLayer, GeoJson, GeoJsonSource, LineLayer, ScreenCoordinate, Style,
+    SymbolAnchor, SymbolLayer,
 };
 use std::cell::RefCell;
 use std::path::Path;
@@ -33,7 +33,7 @@ pub fn init(ui: &MainWindow, map: &Rc<RefCell<MapLibre>>) {
         let map = Rc::downgrade(map);
         move |size| {
             let size =
-                maplibre_native::Size::new(Width(size.width as u32), Height(size.height as u32));
+                maplibre_native::Size { width: size.width as u32, height: size.height as u32 };
             map.upgrade().unwrap().borrow_mut().renderer().set_map_size(size);
         }
     });
@@ -50,8 +50,8 @@ pub fn init(ui: &MainWindow, map: &Rc<RefCell<MapLibre>>) {
                 let size = image.size();
                 let img = slint::SharedPixelBuffer::<slint::Rgba8Pixel>::clone_from_slice(
                     image.buffer(),
-                    size.width(),
-                    size.height(),
+                    size.width,
+                    size.height,
                 );
                 ui_handle
                     .upgrade()
@@ -68,14 +68,14 @@ pub fn init(ui: &MainWindow, map: &Rc<RefCell<MapLibre>>) {
             map.upgrade()
                 .unwrap()
                 .borrow_mut()
-                .set_position(ScreenCoordinate::new(X(x.into()), Y(y.into())));
+                .set_position(ScreenCoordinate { x: x.into(), y: y.into() });
         }
     });
 
     ui.global::<MapAdapter>().on_mouse_move({
         let map = Rc::downgrade(map);
         move |x: f32, y: f32, _z: bool| {
-            let p = ScreenCoordinate::new(X(x.into()), Y(y.into()));
+            let p = ScreenCoordinate { x: x.into(), y: y.into() };
             let map = map.upgrade().unwrap();
             let mut map = map.borrow_mut();
             let delta = p - map.position();
@@ -88,7 +88,7 @@ pub fn init(ui: &MainWindow, map: &Rc<RefCell<MapLibre>>) {
         let map = Rc::downgrade(map);
         move |x: f32, y: f32, delta: f32| {
             const STEP: f64 = 1.2;
-            let pos = ScreenCoordinate::new(X(x.into()), Y(y.into()));
+            let pos = ScreenCoordinate { x: x.into(), y: y.into() };
             let scale = if delta > 0. { STEP } else { 1.0 / STEP };
             map.upgrade().unwrap().borrow_mut().renderer().scale_by(scale, pos);
         }

--- a/examples/slint/src/maplibre/headless.rs
+++ b/examples/slint/src/maplibre/headless.rs
@@ -1,12 +1,8 @@
 use crate::Size;
-use maplibre_native::Continuous;
-use maplibre_native::ImageRenderer;
-use maplibre_native::ImageRendererBuilder;
-use maplibre_native::MapLoadError;
-use maplibre_native::ResourceOptions;
-use maplibre_native::ScreenCoordinate;
-use maplibre_native::tile_server_options::TileServerOptions;
-use maplibre_native::{Latitude, Longitude};
+use maplibre_native::{
+    CameraUpdate, Continuous, ImageRenderer, ImageRendererBuilder, LatLng, MapLoadError,
+    ResourceOptions, ScreenCoordinate, tile_server_options::TileServerOptions,
+};
 use std::cell::RefCell;
 use std::num::NonZeroU32;
 use std::path::Path;
@@ -75,7 +71,13 @@ pub fn create_map(size: Size) -> Rc<RefCell<MapLibre>> {
 
     // setting the camera is important, otherwise maplibre does nothing
     // (no logs are coming and no map gets generated).
-    renderer.set_camera(Latitude(0.0), Longitude(0.0), 0.0, 0.0, 0.0);
+    renderer.update_camera(&CameraUpdate {
+        center: Some(LatLng { lat: 0.0, lng: 0.0 }),
+        zoom: Some(0.0),
+        bearing: Some(0.0),
+        pitch: Some(0.0),
+        ..Default::default()
+    });
     renderer.load_style_from_url(&"https://demotiles.maplibre.org/style.json".parse().unwrap());
 
     let map = Rc::new(RefCell::new(MapLibre::new(renderer)));

--- a/examples/slint/src/maplibre/headless.rs
+++ b/examples/slint/src/maplibre/headless.rs
@@ -71,13 +71,13 @@ pub fn create_map(size: Size) -> Rc<RefCell<MapLibre>> {
 
     // setting the camera is important, otherwise maplibre does nothing
     // (no logs are coming and no map gets generated).
-    renderer.update_camera(&CameraUpdate {
-        center: Some(LatLng { lat: 0.0, lng: 0.0 }),
-        zoom: Some(0.0),
-        bearing: Some(0.0),
-        pitch: Some(0.0),
-        ..Default::default()
-    });
+    renderer.update_camera(
+        &CameraUpdate::new()
+            .center(LatLng { lat: 0.0, lng: 0.0 })
+            .zoom(0.0)
+            .bearing(0.0)
+            .pitch(0.0),
+    );
     renderer.load_style_from_url(&"https://demotiles.maplibre.org/style.json".parse().unwrap());
 
     let map = Rc::new(RefCell::new(MapLibre::new(renderer)));

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -33,37 +33,14 @@ fn log_from_cpp(severity: ffi::EventSeverity, event: ffi::Event, code: i64, mess
     }
 }
 
-/// An x value
-#[derive(Debug)]
-pub struct X(pub f64);
-
-/// An y value
-#[derive(Debug)]
-pub struct Y(pub f64);
-
-/// A width value
-#[derive(Debug)]
-pub struct Width(pub u32);
-
-/// A height value
-#[derive(Debug)]
-pub struct Height(pub u32);
-
 /// A position in screen coordinates
 #[repr(C)]
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct ScreenCoordinate {
-    x: f64,
-    y: f64,
-}
-
-impl ScreenCoordinate {
-    /// Create a new `ScreenCoordinate` object
-    #[must_use]
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn new(x: X, y: Y) -> Self {
-        Self { x: x.0, y: y.0 }
-    }
+    /// Horizontal position in screen pixels.
+    pub x: f64,
+    /// Vertical position in screen pixels.
+    pub y: f64,
 }
 
 impl Sub for ScreenCoordinate {
@@ -77,29 +54,10 @@ impl Sub for ScreenCoordinate {
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct Size {
-    width: u32,
-    height: u32,
-}
-
-impl Size {
-    /// Create a new size object
-    #[must_use]
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn new(width: Width, height: Height) -> Self {
-        Self { width: width.0, height: height.0 }
-    }
-
-    /// get width
-    #[must_use]
-    pub fn width(self) -> u32 {
-        self.width
-    }
-
-    /// get height
-    #[must_use]
-    pub fn height(self) -> u32 {
-        self.height
-    }
+    /// Width in pixels.
+    pub width: u32,
+    /// Height in pixels.
+    pub height: u32,
 }
 
 #[cxx::bridge()]
@@ -696,7 +654,7 @@ pub mod file_source {
     }
 }
 
-#[allow(clippy::borrow_as_ptr)]
+#[allow(clippy::borrow_as_ptr, unused_qualifications)]
 #[cxx::bridge(namespace = "mln::bridge")]
 /// Core FFI definitions and types for the MapLibre bridge.
 pub mod ffi {
@@ -747,6 +705,60 @@ pub mod ffi {
         ///
         /// Note: This option does nothing in Release builds of the SDK
         DepthBuffer = 0b1000_0000, // 1 << 7
+    }
+
+    /// A geographic coordinate.
+    #[derive(Debug, Clone, Copy, PartialEq, Default)]
+    pub struct LatLng {
+        /// Latitude in degrees.
+        pub lat: f64,
+        /// Longitude in degrees.
+        pub lng: f64,
+    }
+
+    /// A geographic bounding box.
+    #[derive(Debug, Clone, Copy, PartialEq, Default)]
+    pub struct LatLngBounds {
+        /// Southwest corner of the bounds.
+        pub southwest: LatLng,
+        /// Northeast corner of the bounds.
+        pub northeast: LatLng,
+    }
+
+    /// Insets from each edge of the renderer viewport.
+    #[derive(Default, Debug, Clone, Copy, PartialEq)]
+    pub struct EdgeInsets {
+        /// Top inset in logical pixels.
+        pub top: f64,
+        /// Left inset in logical pixels.
+        pub left: f64,
+        /// Bottom inset in logical pixels.
+        pub bottom: f64,
+        /// Right inset in logical pixels.
+        pub right: f64,
+    }
+
+    /// FFI representation of partial camera options.
+    #[derive(Debug, Clone, Copy, Default)]
+    pub struct FfiCameraOptions {
+        pub has_center: bool,
+        pub center: LatLng,
+        pub has_center_altitude: bool,
+        pub center_altitude: f64,
+        pub has_padding: bool,
+        pub padding: EdgeInsets,
+        pub has_anchor: bool,
+        pub anchor: ScreenCoordinate,
+        pub has_zoom: bool,
+        pub zoom: f64,
+        pub has_bearing: bool,
+        pub bearing: f64,
+        pub has_pitch: bool,
+        pub pitch: f64,
+        pub has_roll: bool,
+        pub roll: f64,
+        pub has_fov: bool,
+        pub fov: f64,
     }
 
     /// MapLibre Native Event Severity levels
@@ -852,6 +864,7 @@ pub mod ffi {
         type MapRenderer;
         /// In-flight render request.
         type RenderRequest;
+
         /// Ticks the current thread's MapLibre Native run loop once.
         fn currentThreadRunLoopTick();
         /// Creates a new map renderer instance.
@@ -874,14 +887,15 @@ pub mod ffi {
         /// Renders a single frame.
         fn render_once(self: Pin<&mut MapRenderer>);
         /// Submits a render request without waiting for completion.
-        fn submitRender(
+        fn submitRender(self: Pin<&mut MapRenderer>) -> UniquePtr<RenderRequest>;
+        /// Calculates camera options that fit geographic bounds.
+        fn cameraForLatLngBounds(
             self: Pin<&mut MapRenderer>,
-            lat: f64,
-            lon: f64,
-            zoom: f64,
+            bounds: &LatLngBounds,
+            padding: &EdgeInsets,
             bearing: f64,
             pitch: f64,
-        ) -> UniquePtr<RenderRequest>;
+        ) -> FfiCameraOptions;
         /// Returns whether a render request has completed.
         fn isReady(self: &RenderRequest) -> bool;
         /// Returns whether a completed render request failed.
@@ -892,15 +906,8 @@ pub mod ffi {
         fn takeImage(self: Pin<&mut RenderRequest>) -> UniquePtr<CxxString>;
         /// Sets debug visualization flags.
         fn setDebugFlags(self: Pin<&mut MapRenderer>, flags: MapDebugOptions);
-        /// Sets the camera position and orientation.
-        fn setCamera(
-            self: Pin<&mut MapRenderer>,
-            lat: f64,
-            lon: f64,
-            zoom: f64,
-            bearing: f64,
-            pitch: f64,
-        );
+        /// Jumps to the requested camera options.
+        fn jumpTo(self: Pin<&mut MapRenderer>, camera: &FfiCameraOptions);
         /// Moves the camera by the given delta.
         fn moveBy(self: Pin<&mut MapRenderer>, delta: &ScreenCoordinate);
         /// Scales the camera based on the given scale factor.
@@ -985,12 +992,12 @@ unsafe impl cxx::ExternType for ScreenCoordinate {
 
 #[cfg(test)]
 mod test {
-    use crate::{ScreenCoordinate, X, Y};
+    use crate::ScreenCoordinate;
 
     #[test]
     fn screen_coordinate_diff() {
-        let s1 = ScreenCoordinate::new(X(5.), Y(-1.));
-        let s2 = ScreenCoordinate::new(X(3.), Y(-10.));
+        let s1 = ScreenCoordinate { x: 5., y: -1. };
+        let s2 = ScreenCoordinate { x: 3., y: -10. };
 
         let res = s1 - s2;
         assert!((res.x - 2.).abs() < 0.00001);

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -739,7 +739,7 @@ pub mod ffi {
     }
 
     /// FFI representation of partial camera options.
-    #[derive(Debug, Clone, Copy, Default)]
+    #[derive(Debug, Clone, Copy, PartialEq, Default)]
     pub struct FfiCameraOptions {
         pub has_center: bool,
         pub center: LatLng,

--- a/src/cpp/bridge.cpp
+++ b/src/cpp/bridge.cpp
@@ -1,4 +1,3 @@
-#include "map_renderer.h"
 #include "rust_log_observer.h"
 #include "maplibre_native/src/bridge.rs.h"
 #include <mbgl/util/logging.hpp>
@@ -17,7 +16,6 @@ bool RustLogObserver::onRecord(mbgl::EventSeverity severity, mbgl::Event event, 
     log_from_cpp(severity, event, code, msg);
     return true;
 }
-
 
 } // namespace bridge
 } // namespace mln

--- a/src/cpp/camera.cpp
+++ b/src/cpp/camera.cpp
@@ -1,0 +1,109 @@
+#include "maplibre_native/src/bridge.rs.h"
+
+namespace mln {
+namespace bridge {
+namespace {
+
+mbgl::CameraOptions toCameraOptions(const FfiCameraOptions& camera) {
+    mbgl::CameraOptions options;
+    if (camera.has_center) {
+        options.withCenter(mbgl::LatLng{camera.center.lat, camera.center.lng});
+    }
+    if (camera.has_center_altitude) {
+        options.withCenterAltitude(camera.center_altitude);
+    }
+    if (camera.has_padding) {
+        options.withPadding(mbgl::EdgeInsets{
+            camera.padding.top,
+            camera.padding.left,
+            camera.padding.bottom,
+            camera.padding.right,
+        });
+    }
+    if (camera.has_anchor) {
+        options.withAnchor(camera.anchor);
+    }
+    if (camera.has_zoom) {
+        options.withZoom(camera.zoom);
+    }
+    if (camera.has_bearing) {
+        options.withBearing(camera.bearing);
+    }
+    if (camera.has_pitch) {
+        options.withPitch(camera.pitch);
+    }
+    if (camera.has_roll) {
+        options.withRoll(camera.roll);
+    }
+    if (camera.has_fov) {
+        options.withFov(camera.fov);
+    }
+    return options;
+}
+
+FfiCameraOptions fromCameraOptions(const mbgl::CameraOptions& options) {
+    FfiCameraOptions camera{};
+    if (options.center) {
+        camera.has_center = true;
+        camera.center = LatLng{options.center->latitude(), options.center->longitude()};
+    }
+    if (options.centerAltitude) {
+        camera.has_center_altitude = true;
+        camera.center_altitude = *options.centerAltitude;
+    }
+    if (options.padding) {
+        camera.has_padding = true;
+        camera.padding = EdgeInsets{
+            options.padding->top(),
+            options.padding->left(),
+            options.padding->bottom(),
+            options.padding->right(),
+        };
+    }
+    if (options.anchor) {
+        camera.has_anchor = true;
+        camera.anchor = *options.anchor;
+    }
+    if (options.zoom) {
+        camera.has_zoom = true;
+        camera.zoom = *options.zoom;
+    }
+    if (options.bearing) {
+        camera.has_bearing = true;
+        camera.bearing = *options.bearing;
+    }
+    if (options.pitch) {
+        camera.has_pitch = true;
+        camera.pitch = *options.pitch;
+    }
+    if (options.roll) {
+        camera.has_roll = true;
+        camera.roll = *options.roll;
+    }
+    if (options.fov) {
+        camera.has_fov = true;
+        camera.fov = *options.fov;
+    }
+    return camera;
+}
+
+} // namespace
+
+FfiCameraOptions MapRenderer::cameraForLatLngBounds(const LatLngBounds& bounds,
+                                                   const EdgeInsets& padding,
+                                                   double bearing,
+                                                   double pitch) {
+    const mbgl::LatLngBounds mbglBounds = mbgl::LatLngBounds::hull(
+        {bounds.southwest.lat, bounds.southwest.lng},
+        {bounds.northeast.lat, bounds.northeast.lng});
+    const mbgl::EdgeInsets mbglPadding{padding.top, padding.left, padding.bottom, padding.right};
+
+    return fromCameraOptions(map->cameraForLatLngBounds(mbglBounds, mbglPadding, bearing, pitch));
+}
+
+void MapRenderer::jumpTo(const FfiCameraOptions& cameraOptions) {
+    map->jumpTo(toCameraOptions(cameraOptions));
+}
+
+} // namespace bridge
+} // namespace mln

--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -31,6 +31,9 @@ constexpr size_t BYTES_PER_PIXEL = 4; // rgba
 
 struct BridgeImage;
 class RenderRequest;
+struct FfiCameraOptions;
+struct LatLngBounds;
+struct EdgeInsets;
 
 inline mbgl::util::RunLoop& threadRunLoop() {
     // MapLibre Native's RunLoop is thread-affine. Keep one private loop per
@@ -143,7 +146,12 @@ public:
         frontend->renderOnce(*map);
     }
 
-    std::unique_ptr<RenderRequest> submitRender(double lat, double lon, double zoom, double bearing, double pitch);
+    std::unique_ptr<RenderRequest> submitRender();
+
+    FfiCameraOptions cameraForLatLngBounds(const LatLngBounds& bounds,
+                                           const EdgeInsets& padding,
+                                           double bearing,
+                                           double pitch);
 
     std::unique_ptr<std::string> readStillImageBytes() {
         return encodeImage(frontend->readStillImage());
@@ -160,11 +168,7 @@ public:
         map->setDebug(debugFlags);
     }
 
-    void setCamera(double lat, double lon, double zoom, double bearing, double pitch) {
-        mbgl::CameraOptions cameraOptions;
-        cameraOptions.withCenter(mbgl::LatLng{lat, lon}).withZoom(zoom).withBearing(bearing).withPitch(pitch);
-        map->jumpTo(cameraOptions);
-    }
+    void jumpTo(const FfiCameraOptions& cameraOptions);
 
     void moveBy(const mbgl::ScreenCoordinate& delta) {
         map->moveBy(delta);
@@ -243,14 +247,7 @@ private:
     bool taken = false;
 };
 
-inline std::unique_ptr<RenderRequest> MapRenderer::submitRender(
-        double lat,
-        double lon,
-        double zoom,
-        double bearing,
-        double pitch) {
-    setCamera(lat, lon, zoom, bearing, pitch);
-
+inline std::unique_ptr<RenderRequest> MapRenderer::submitRender() {
     auto request = std::make_unique<RenderRequest>();
     auto state = request->getState();
 

--- a/src/renderer/camera.rs
+++ b/src/renderer/camera.rs
@@ -1,0 +1,95 @@
+use crate::bridge::ffi::{EdgeInsets, FfiCameraOptions, LatLng};
+use crate::ScreenCoordinate;
+
+impl EdgeInsets {
+    /// Creates equal insets for all edges.
+    #[must_use]
+    pub fn all(value: f64) -> Self {
+        Self { top: value, left: value, bottom: value, right: value }
+    }
+}
+
+/// A partial camera update.
+///
+/// All fields are optional, so this can represent partial camera updates such
+/// as changing only the zoom or only the viewport padding.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct CameraUpdate {
+    /// Geographic coordinate at the center of the viewport.
+    pub center: Option<LatLng>,
+    /// Altitude of the center coordinate.
+    pub center_altitude: Option<f64>,
+    /// Insets from the viewport edges.
+    pub padding: Option<EdgeInsets>,
+    /// Screen coordinate to keep fixed while changing camera values.
+    pub anchor: Option<ScreenCoordinate>,
+    /// Zoom level.
+    pub zoom: Option<f64>,
+    /// Bearing in degrees clockwise from north.
+    pub bearing: Option<f64>,
+    /// Pitch in degrees.
+    pub pitch: Option<f64>,
+    /// Roll in degrees.
+    pub roll: Option<f64>,
+    /// Field of view in degrees.
+    pub fov: Option<f64>,
+}
+
+impl CameraUpdate {
+    pub(crate) fn from_camera_options(options: FfiCameraOptions) -> Self {
+        Self {
+            center: options.has_center.then_some(options.center),
+            center_altitude: options.has_center_altitude.then_some(options.center_altitude),
+            padding: options.has_padding.then_some(options.padding),
+            anchor: options.has_anchor.then_some(options.anchor),
+            zoom: options.has_zoom.then_some(options.zoom),
+            bearing: options.has_bearing.then_some(options.bearing),
+            pitch: options.has_pitch.then_some(options.pitch),
+            roll: options.has_roll.then_some(options.roll),
+            fov: options.has_fov.then_some(options.fov),
+        }
+    }
+
+    pub(crate) fn to_camera_options(&self) -> FfiCameraOptions {
+        let mut options = FfiCameraOptions::default();
+
+        if let Some(center) = self.center {
+            options.has_center = true;
+            options.center = center;
+        }
+        if let Some(center_altitude) = self.center_altitude {
+            options.has_center_altitude = true;
+            options.center_altitude = center_altitude;
+        }
+        if let Some(padding) = self.padding {
+            options.has_padding = true;
+            options.padding = padding;
+        }
+        if let Some(anchor) = self.anchor {
+            options.has_anchor = true;
+            options.anchor = anchor;
+        }
+        if let Some(zoom) = self.zoom {
+            options.has_zoom = true;
+            options.zoom = zoom;
+        }
+        if let Some(bearing) = self.bearing {
+            options.has_bearing = true;
+            options.bearing = bearing;
+        }
+        if let Some(pitch) = self.pitch {
+            options.has_pitch = true;
+            options.pitch = pitch;
+        }
+        if let Some(roll) = self.roll {
+            options.has_roll = true;
+            options.roll = roll;
+        }
+        if let Some(fov) = self.fov {
+            options.has_fov = true;
+            options.fov = fov;
+        }
+
+        options
+    }
+}

--- a/src/renderer/camera.rs
+++ b/src/renderer/camera.rs
@@ -15,81 +15,93 @@ impl EdgeInsets {
 /// as changing only the zoom or only the viewport padding.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct CameraUpdate {
-    /// Geographic coordinate at the center of the viewport.
-    pub center: Option<LatLng>,
-    /// Altitude of the center coordinate.
-    pub center_altitude: Option<f64>,
-    /// Insets from the viewport edges.
-    pub padding: Option<EdgeInsets>,
-    /// Screen coordinate to keep fixed while changing camera values.
-    pub anchor: Option<ScreenCoordinate>,
-    /// Zoom level.
-    pub zoom: Option<f64>,
-    /// Bearing in degrees clockwise from north.
-    pub bearing: Option<f64>,
-    /// Pitch in degrees.
-    pub pitch: Option<f64>,
-    /// Roll in degrees.
-    pub roll: Option<f64>,
-    /// Field of view in degrees.
-    pub fov: Option<f64>,
+    options: FfiCameraOptions,
 }
 
 impl CameraUpdate {
+    /// Creates an empty camera update.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the geographic coordinate at the center of the viewport.
+    #[must_use]
+    pub fn center(mut self, center: LatLng) -> Self {
+        self.options.has_center = true;
+        self.options.center = center;
+        self
+    }
+
+    /// Sets the altitude of the center coordinate.
+    #[must_use]
+    pub fn center_altitude(mut self, center_altitude: f64) -> Self {
+        self.options.has_center_altitude = true;
+        self.options.center_altitude = center_altitude;
+        self
+    }
+
+    /// Sets the insets from the viewport edges.
+    #[must_use]
+    pub fn padding(mut self, padding: EdgeInsets) -> Self {
+        self.options.has_padding = true;
+        self.options.padding = padding;
+        self
+    }
+
+    /// Sets the screen coordinate to keep fixed while changing camera values.
+    #[must_use]
+    pub fn anchor(mut self, anchor: ScreenCoordinate) -> Self {
+        self.options.has_anchor = true;
+        self.options.anchor = anchor;
+        self
+    }
+
+    /// Sets the zoom level.
+    #[must_use]
+    pub fn zoom(mut self, zoom: f64) -> Self {
+        self.options.has_zoom = true;
+        self.options.zoom = zoom;
+        self
+    }
+
+    /// Sets the bearing in degrees clockwise from north.
+    #[must_use]
+    pub fn bearing(mut self, bearing: f64) -> Self {
+        self.options.has_bearing = true;
+        self.options.bearing = bearing;
+        self
+    }
+
+    /// Sets the pitch in degrees.
+    #[must_use]
+    pub fn pitch(mut self, pitch: f64) -> Self {
+        self.options.has_pitch = true;
+        self.options.pitch = pitch;
+        self
+    }
+
+    /// Sets the roll in degrees.
+    #[must_use]
+    pub fn roll(mut self, roll: f64) -> Self {
+        self.options.has_roll = true;
+        self.options.roll = roll;
+        self
+    }
+
+    /// Sets the field of view in degrees.
+    #[must_use]
+    pub fn fov(mut self, fov: f64) -> Self {
+        self.options.has_fov = true;
+        self.options.fov = fov;
+        self
+    }
+
     pub(crate) fn from_camera_options(options: FfiCameraOptions) -> Self {
-        Self {
-            center: options.has_center.then_some(options.center),
-            center_altitude: options.has_center_altitude.then_some(options.center_altitude),
-            padding: options.has_padding.then_some(options.padding),
-            anchor: options.has_anchor.then_some(options.anchor),
-            zoom: options.has_zoom.then_some(options.zoom),
-            bearing: options.has_bearing.then_some(options.bearing),
-            pitch: options.has_pitch.then_some(options.pitch),
-            roll: options.has_roll.then_some(options.roll),
-            fov: options.has_fov.then_some(options.fov),
-        }
+        Self { options }
     }
 
     pub(crate) fn to_camera_options(&self) -> FfiCameraOptions {
-        let mut options = FfiCameraOptions::default();
-
-        if let Some(center) = self.center {
-            options.has_center = true;
-            options.center = center;
-        }
-        if let Some(center_altitude) = self.center_altitude {
-            options.has_center_altitude = true;
-            options.center_altitude = center_altitude;
-        }
-        if let Some(padding) = self.padding {
-            options.has_padding = true;
-            options.padding = padding;
-        }
-        if let Some(anchor) = self.anchor {
-            options.has_anchor = true;
-            options.anchor = anchor;
-        }
-        if let Some(zoom) = self.zoom {
-            options.has_zoom = true;
-            options.zoom = zoom;
-        }
-        if let Some(bearing) = self.bearing {
-            options.has_bearing = true;
-            options.bearing = bearing;
-        }
-        if let Some(pitch) = self.pitch {
-            options.has_pitch = true;
-            options.pitch = pitch;
-        }
-        if let Some(roll) = self.roll {
-            options.has_roll = true;
-            options.roll = roll;
-        }
-        if let Some(fov) = self.fov {
-            options.has_fov = true;
-            options.fov = fov;
-        }
-
-        options
+        self.options
     }
 }

--- a/src/renderer/image_renderer.rs
+++ b/src/renderer/image_renderer.rs
@@ -3,7 +3,7 @@ use crate::bridge::ffi;
 use crate::bridge::ffi::BridgeImage;
 use crate::renderer::MapDebugOptions;
 use crate::RunLoopHandle;
-use crate::{Latitude, Longitude, ScreenCoordinate, Size};
+use crate::{CameraUpdate, EdgeInsets, LatLng, LatLngBounds, ScreenCoordinate, Size};
 use cxx::UniquePtr;
 use image::{ImageBuffer, Rgba};
 use std::f64::consts::PI;
@@ -20,7 +20,7 @@ use std::path::Path;
 ///
 /// ```no_run
 /// # fn foo() {
-/// use maplibre_native::{ImageRendererBuilder, Image};
+/// use maplibre_native::{CameraUpdate, Image, ImageRendererBuilder, LatLng};
 /// use std::num::NonZeroU32;
 ///
 /// let mut renderer = ImageRendererBuilder::new()
@@ -28,7 +28,12 @@ use std::path::Path;
 ///     .build_static_renderer();
 ///
 /// renderer.load_style_from_url(&"https://demotiles.maplibre.org/style.json".parse().unwrap());
-/// let image: Image = renderer.render_static(0.0, 0.0, 0.0, 0.0, 0.0).unwrap();
+/// let camera = CameraUpdate {
+///     center: Some(LatLng { lat: 0.0, lng: 0.0 }),
+///     zoom: Some(0.0),
+///     ..Default::default()
+/// };
+/// let image: Image = renderer.render_static(&camera).unwrap();
 ///
 /// // Access the underlying ImageBuffer for all operations
 /// let img_buffer = image.as_image();
@@ -215,46 +220,57 @@ impl<S> ImageRenderer<S> {
     pub fn map_observer(&mut self) -> MapObserver {
         MapObserver::new(self.instance.pin_mut().observer())
     }
+
+    /// Calculates a camera update that fits geographic bounds.
+    #[must_use]
+    pub fn camera_for_bounds(
+        &mut self,
+        bounds: LatLngBounds,
+        padding: Option<EdgeInsets>,
+        bearing: f64,
+        pitch: f64,
+    ) -> CameraUpdate {
+        let padding = padding.unwrap_or_default();
+        let camera =
+            self.instance.pin_mut().cameraForLatLngBounds(&bounds, &padding, bearing, pitch);
+        CameraUpdate::from_camera_options(camera)
+    }
+
+    fn submit_with_camera(
+        &mut self,
+        camera: &CameraUpdate,
+    ) -> Result<RenderRequest<'_, S>, RenderingError> {
+        if !self.style_specified {
+            return Err(RenderingError::StyleNotSpecified);
+        }
+        self.instance.pin_mut().jumpTo(&camera.to_camera_options());
+        let request = self.instance.pin_mut().submitRender();
+        Ok(RenderRequest { instance: request, _renderer: PhantomData, _not_send: PhantomData })
+    }
 }
 
 impl ImageRenderer<Static> {
-    /// Render the map as a static [`Image`] where the camera can be freely controlled.
+    /// Render the map as a static [`Image`] using camera options.
     ///
     /// # Errors
     /// If no style has been loaded.
-    pub fn render_static(
-        &mut self,
-        lat: f64,
-        lon: f64,
-        zoom: f64,
-        bearing: f64,
-        pitch: f64,
-    ) -> Result<Image, RenderingError> {
-        self.submit_render_static(lat, lon, zoom, bearing, pitch)?.wait()
+    pub fn render_static(&mut self, camera: &CameraUpdate) -> Result<Image, RenderingError> {
+        self.submit_render_static(camera)?.wait()
     }
 
-    /// Submits a static render request without blocking.
+    /// Submits a static render request using camera options.
     ///
     /// Use this when driving one or more requests manually with
-    /// [`RunLoopHandle::tick`]. Use [`render_static`](Self::render_static) for
-    /// the blocking convenience API.
+    /// [`RunLoopHandle::tick`]. Use [`render_static`](Self::render_static) for the
+    /// blocking convenience API.
     ///
     /// # Errors
     /// If no style has been loaded.
     pub fn submit_render_static(
         &mut self,
-        lat: f64,
-        lon: f64,
-        zoom: f64,
-        bearing: f64,
-        pitch: f64,
+        camera: &CameraUpdate,
     ) -> Result<RenderRequest<'_, Static>, RenderingError> {
-        if !self.style_specified {
-            return Err(RenderingError::StyleNotSpecified);
-        }
-
-        let request = self.instance.pin_mut().submitRender(lat, lon, zoom, bearing, pitch);
-        Ok(RenderRequest { instance: request, _renderer: PhantomData, _not_send: PhantomData })
+        self.submit_with_camera(camera)
     }
 }
 
@@ -281,13 +297,14 @@ impl ImageRenderer<Tile> {
         x: u32,
         y: u32,
     ) -> Result<RenderRequest<'_, Tile>, RenderingError> {
-        if !self.style_specified {
-            return Err(RenderingError::StyleNotSpecified);
-        }
-
-        let (lat, lon) = coords_to_lat_lon(f64::from(zoom), x, y);
-        let request = self.instance.pin_mut().submitRender(lat.0, lon.0, f64::from(zoom), 0.0, 0.0);
-        Ok(RenderRequest { instance: request, _renderer: PhantomData, _not_send: PhantomData })
+        let center = tile_coords_to_latlng(f64::from(zoom), x, y);
+        self.submit_with_camera(&CameraUpdate {
+            center: Some(center),
+            zoom: Some(f64::from(zoom)),
+            bearing: Some(0.0),
+            pitch: Some(0.0),
+            ..Default::default()
+        })
     }
 }
 
@@ -318,21 +335,14 @@ impl ImagePtr {
 }
 
 impl ImageRenderer<Continuous> {
-    /// Set the camera position using geographic coordinates.
+    /// Applies a partial camera update immediately.
     ///
-    /// See [this grapic](https://en.wikipedia.org/wiki/Degrees_of_freedom_(mechanics)#/media/File:Flight_dynamics_with_text.svg)
+    /// See [this graphic](https://en.wikipedia.org/wiki/Degrees_of_freedom_(mechanics)#/media/File:Flight_dynamics_with_text.svg)
     /// as a reminder what bearing, pitch (and yaw) is.
     ///
     /// Important: Without setting the camera initially no image will be generated!
-    pub fn set_camera(
-        &mut self,
-        latitude: Latitude,
-        longitude: Longitude,
-        zoom: f64,
-        bearing: f64,
-        pitch: f64,
-    ) {
-        self.instance.pin_mut().setCamera(latitude.0, longitude.0, zoom, bearing, pitch);
+    pub fn update_camera(&mut self, camera: &CameraUpdate) {
+        self.instance.pin_mut().jumpTo(&camera.to_camera_options());
     }
 
     /// Move map by
@@ -357,12 +367,12 @@ impl ImageRenderer<Continuous> {
 }
 
 #[allow(clippy::cast_precision_loss)]
-fn coords_to_lat_lon(zoom: f64, x: u32, y: u32) -> (Latitude, Longitude) {
+fn tile_coords_to_latlng(zoom: f64, x: u32, y: u32) -> LatLng {
     // https://github.com/oldmammuth/slippy_map_tilenames/blob/058678480f4b50b622cda7a48b98647292272346/src/lib.rs#L114
     let zz = 2_f64.powf(zoom);
     let lng = (f64::from(x) + 0.5) / zz * 360_f64 - 180_f64;
     let lat = ((PI * (1_f64 - 2_f64 * (f64::from(y) + 0.5) / zz)).sinh()).atan().to_degrees();
-    (Latitude(lat), Longitude(lng))
+    LatLng { lat, lng }
 }
 
 /// Errors that can occur during map rendering operations.
@@ -381,21 +391,19 @@ pub enum RenderingError {
 
 #[cfg(test)]
 mod tests {
-    use super::{coords_to_lat_lon, Latitude, Longitude};
+    use super::tile_coords_to_latlng;
 
     #[test]
     fn converts_tile_zero_to_geographic_center() {
-        let (lat, lon) = coords_to_lat_lon(0.0, 0, 0);
-        assert!(matches!(lat, Latitude(v) if v.abs() < f64::EPSILON));
-        assert!(matches!(lon, Longitude(v) if v.abs() < f64::EPSILON));
+        let center = tile_coords_to_latlng(0.0, 0, 0);
+        assert!(center.lat.abs() < f64::EPSILON);
+        assert!(center.lng.abs() < f64::EPSILON);
     }
 
     #[test]
     fn tile_coordinate_conversion_returns_typed_coordinates() {
-        let (lat, lon) = coords_to_lat_lon(1.0, 1, 1);
-        let Latitude(lat) = lat;
-        let Longitude(lon) = lon;
-        assert!((-90.0..=90.0).contains(&lat));
-        assert!((-180.0..=180.0).contains(&lon));
+        let center = tile_coords_to_latlng(1.0, 1, 1);
+        assert!((-90.0..=90.0).contains(&center.lat));
+        assert!((-180.0..=180.0).contains(&center.lng));
     }
 }

--- a/src/renderer/image_renderer.rs
+++ b/src/renderer/image_renderer.rs
@@ -28,11 +28,9 @@ use std::path::Path;
 ///     .build_static_renderer();
 ///
 /// renderer.load_style_from_url(&"https://demotiles.maplibre.org/style.json".parse().unwrap());
-/// let camera = CameraUpdate {
-///     center: Some(LatLng { lat: 0.0, lng: 0.0 }),
-///     zoom: Some(0.0),
-///     ..Default::default()
-/// };
+/// let camera = CameraUpdate::new()
+///     .center(LatLng { lat: 0.0, lng: 0.0 })
+///     .zoom(0.0);
 /// let image: Image = renderer.render_static(&camera).unwrap();
 ///
 /// // Access the underlying ImageBuffer for all operations
@@ -298,13 +296,9 @@ impl ImageRenderer<Tile> {
         y: u32,
     ) -> Result<RenderRequest<'_, Tile>, RenderingError> {
         let center = tile_coords_to_latlng(f64::from(zoom), x, y);
-        self.submit_with_camera(&CameraUpdate {
-            center: Some(center),
-            zoom: Some(f64::from(zoom)),
-            bearing: Some(0.0),
-            pitch: Some(0.0),
-            ..Default::default()
-        })
+        self.submit_with_camera(
+            &CameraUpdate::new().center(center).zoom(f64::from(zoom)).bearing(0.0).pitch(0.0),
+        )
     }
 }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,5 +1,6 @@
 mod builder;
 pub mod callbacks;
+mod camera;
 pub mod file_source;
 mod image_renderer;
 mod map_observer;
@@ -9,11 +10,12 @@ pub mod tile_server_options;
 
 pub use crate::bridge::file_source::{FsErrorReason, ResourceKind};
 pub use crate::bridge::{
-    ffi::{MapDebugOptions, MapMode},
+    ffi::{EdgeInsets, LatLng, LatLngBounds, MapDebugOptions, MapMode},
     map_observer::{MapLoadError, MapObserverCameraChangeMode},
-    set_log_thread_enabled, Height, ScreenCoordinate, Size, Width, X, Y,
+    set_log_thread_enabled, ScreenCoordinate, Size,
 };
 pub use builder::ImageRendererBuilder;
+pub use camera::CameraUpdate;
 pub use file_source::{register_file_source_callback, FileSourceRequestCallback, FsResponse};
 pub use image_renderer::{
     Continuous, Image, ImageRenderer, RenderRequest, RenderingError, Static, Tile,
@@ -21,11 +23,3 @@ pub use image_renderer::{
 pub use map_observer::MapObserver;
 pub use resource_options::ResourceOptions;
 pub use run_loop::RunLoopHandle;
-
-/// Latitude coordinate value.
-#[derive(Debug, Clone, Copy)]
-pub struct Latitude(pub f64);
-
-/// Longitude coordinate value.
-#[derive(Debug, Clone, Copy)]
-pub struct Longitude(pub f64);

--- a/src/style/map_style.rs
+++ b/src/style/map_style.rs
@@ -1,7 +1,7 @@
 use image::DynamicImage;
 
 use crate::bridge::ffi;
-use crate::{Height, ImageId, ImageRenderer, Layer, LayerId, Source, SourceId, StyleError, Width};
+use crate::{ImageId, ImageRenderer, Layer, LayerId, Source, SourceId, StyleError};
 
 /// The style of the map.
 #[derive(Debug)]
@@ -40,7 +40,7 @@ impl<'a, S> Style<'a, S> {
         self.image_renderer.instance.pin_mut().style_add_image(
             id,
             image.as_bytes(),
-            ffi::Size::new(Width(image.width()), Height(image.height())),
+            ffi::Size { width: image.width(), height: image.height() },
             signed_distance_field,
         )?;
         Ok(ImageId::new(id.to_owned()))

--- a/tests/file_source_callback.rs
+++ b/tests/file_source_callback.rs
@@ -66,13 +66,13 @@ fn file_source_callback_serves_inline_style() {
     renderer.set_map_size(Size { width: 64, height: 64 });
 
     let image = renderer
-        .render_static(&CameraUpdate {
-            center: Some(LatLng { lat: 0.0, lng: 0.0 }),
-            zoom: Some(0.0),
-            bearing: Some(0.0),
-            pitch: Some(0.0),
-            ..Default::default()
-        })
+        .render_static(
+            &CameraUpdate::new()
+                .center(LatLng { lat: 0.0, lng: 0.0 })
+                .zoom(0.0)
+                .bearing(0.0)
+                .pitch(0.0),
+        )
         .expect("render should succeed");
 
     // Dimensions: 64x64 logical * 1.0 ratio = 64x64 physical.

--- a/tests/file_source_callback.rs
+++ b/tests/file_source_callback.rs
@@ -11,8 +11,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use maplibre_native::{
-    register_file_source_callback, FsResponse, Height, ImageRendererBuilder, ResourceKind, Size,
-    Width,
+    register_file_source_callback, CameraUpdate, FsResponse, ImageRendererBuilder, LatLng,
+    ResourceKind, Size,
 };
 
 // A minimal style that renders a solid background. No tile sources — keeps
@@ -63,9 +63,17 @@ fn file_source_callback_serves_inline_style() {
     // than `load_style_from_path` so no file on disk is required.
     let url: url::Url = "https://example.invalid/inline-style.json".parse().unwrap();
     renderer.load_style_from_url(&url);
-    renderer.set_map_size(Size::new(Width(64), Height(64)));
+    renderer.set_map_size(Size { width: 64, height: 64 });
 
-    let image = renderer.render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("render should succeed");
+    let image = renderer
+        .render_static(&CameraUpdate {
+            center: Some(LatLng { lat: 0.0, lng: 0.0 }),
+            zoom: Some(0.0),
+            bearing: Some(0.0),
+            pitch: Some(0.0),
+            ..Default::default()
+        })
+        .expect("render should succeed");
 
     // Dimensions: 64x64 logical * 1.0 ratio = 64x64 physical.
     let buf = image.as_image();

--- a/tests/image_renderer.rs
+++ b/tests/image_renderer.rs
@@ -1,6 +1,8 @@
 //! Integration tests for image renderer request and run loop behavior.
 
-use maplibre_native::{ImageRendererBuilder, RunLoopHandle};
+use maplibre_native::{
+    CameraUpdate, EdgeInsets, ImageRendererBuilder, LatLng, LatLngBounds, RunLoopHandle,
+};
 use std::{
     num::NonZeroU32,
     path::PathBuf,
@@ -9,6 +11,16 @@ use std::{
 };
 
 const RENDER_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn test_camera() -> CameraUpdate {
+    CameraUpdate {
+        center: Some(LatLng { lat: 0.0, lng: 0.0 }),
+        zoom: Some(0.0),
+        bearing: Some(0.0),
+        pitch: Some(0.0),
+        ..Default::default()
+    }
+}
 
 fn fixture_path(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name)
@@ -39,7 +51,7 @@ fn thread_run_loop_supports_worker_threads() {
                 .load_style_from_path(fixture_path("test-style.json"))
                 .expect("test style should load");
             let image = renderer
-                .render_static(0.0, 0.0, 0.0, 0.0, 0.0)
+                .render_static(&test_camera())
                 .expect("thread run loop should render");
 
             assert_eq!(image.as_image().width(), 128);
@@ -67,9 +79,10 @@ fn multiple_renderers_render_on_single_thread() {
     second.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
 
     let first_request =
-        first.submit_render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("first render should submit");
-    let second_request =
-        second.submit_render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("second render should submit");
+        first.submit_render_static(&test_camera()).expect("first render should submit");
+    let second_request = second
+        .submit_render_static(&test_camera())
+        .expect("second render should submit");
 
     // Both requests are driven from the same thread-local run loop.
     tick_until_ready(|| first_request.is_ready() && second_request.is_ready());
@@ -93,7 +106,7 @@ fn load_style_from_json_renders() {
     renderer.load_style_from_json(include_str!("fixtures/test-style.json"));
 
     let request = renderer
-        .submit_render_static(0.0, 0.0, 0.0, 0.0, 0.0)
+        .submit_render_static(&test_camera())
         .expect("JSON style render should submit");
     tick_until_ready(|| request.is_ready());
 
@@ -121,6 +134,30 @@ fn tile_render_request_renders() {
 }
 
 #[test]
+fn camera_for_bounds_renders() {
+    let mut renderer = ImageRendererBuilder::new()
+        .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
+        .with_pixel_ratio(1.0)
+        .build_static_renderer();
+
+    renderer.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
+
+    let bounds = LatLngBounds {
+        southwest: LatLng { lat: -10.0, lng: -10.0 },
+        northeast: LatLng { lat: 10.0, lng: 10.0 },
+    };
+    let camera = renderer.camera_for_bounds(bounds, Some(EdgeInsets::all(8.0)), 0.0, 0.0);
+    let request = renderer
+        .submit_render_static(&camera)
+        .expect("bounds-fit render should submit");
+    tick_until_ready(|| request.is_ready());
+
+    let image = request.finish().expect("bounds-fit renderer should render");
+    assert_eq!(image.as_image().width(), 128);
+    assert_eq!(image.as_image().height(), 128);
+}
+
+#[test]
 fn dropping_render_request_before_renderer_is_safe() {
     let mut renderer = ImageRendererBuilder::new()
         .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
@@ -130,7 +167,7 @@ fn dropping_render_request_before_renderer_is_safe() {
     renderer.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
 
     let request =
-        renderer.submit_render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("render should submit");
+        renderer.submit_render_static(&test_camera()).expect("render should submit");
     drop(request);
     drop(renderer);
 }

--- a/tests/image_renderer.rs
+++ b/tests/image_renderer.rs
@@ -13,13 +13,7 @@ use std::{
 const RENDER_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn test_camera() -> CameraUpdate {
-    CameraUpdate {
-        center: Some(LatLng { lat: 0.0, lng: 0.0 }),
-        zoom: Some(0.0),
-        bearing: Some(0.0),
-        pitch: Some(0.0),
-        ..Default::default()
-    }
+    CameraUpdate::new().center(LatLng { lat: 0.0, lng: 0.0 }).zoom(0.0).bearing(0.0).pitch(0.0)
 }
 
 fn fixture_path(name: &str) -> PathBuf {

--- a/tests/image_renderer.rs
+++ b/tests/image_renderer.rs
@@ -50,9 +50,8 @@ fn thread_run_loop_supports_worker_threads() {
             renderer
                 .load_style_from_path(fixture_path("test-style.json"))
                 .expect("test style should load");
-            let image = renderer
-                .render_static(&test_camera())
-                .expect("thread run loop should render");
+            let image =
+                renderer.render_static(&test_camera()).expect("thread run loop should render");
 
             assert_eq!(image.as_image().width(), 128);
             assert_eq!(image.as_image().height(), 128);
@@ -80,9 +79,8 @@ fn multiple_renderers_render_on_single_thread() {
 
     let first_request =
         first.submit_render_static(&test_camera()).expect("first render should submit");
-    let second_request = second
-        .submit_render_static(&test_camera())
-        .expect("second render should submit");
+    let second_request =
+        second.submit_render_static(&test_camera()).expect("second render should submit");
 
     // Both requests are driven from the same thread-local run loop.
     tick_until_ready(|| first_request.is_ready() && second_request.is_ready());
@@ -105,9 +103,8 @@ fn load_style_from_json_renders() {
 
     renderer.load_style_from_json(include_str!("fixtures/test-style.json"));
 
-    let request = renderer
-        .submit_render_static(&test_camera())
-        .expect("JSON style render should submit");
+    let request =
+        renderer.submit_render_static(&test_camera()).expect("JSON style render should submit");
     tick_until_ready(|| request.is_ready());
 
     let image = request.finish().expect("JSON style should render");
@@ -147,9 +144,7 @@ fn camera_for_bounds_renders() {
         northeast: LatLng { lat: 10.0, lng: 10.0 },
     };
     let camera = renderer.camera_for_bounds(bounds, Some(EdgeInsets::all(8.0)), 0.0, 0.0);
-    let request = renderer
-        .submit_render_static(&camera)
-        .expect("bounds-fit render should submit");
+    let request = renderer.submit_render_static(&camera).expect("bounds-fit render should submit");
     tick_until_ready(|| request.is_ready());
 
     let image = request.finish().expect("bounds-fit renderer should render");
@@ -166,8 +161,7 @@ fn dropping_render_request_before_renderer_is_safe() {
 
     renderer.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
 
-    let request =
-        renderer.submit_render_static(&test_camera()).expect("render should submit");
+    let request = renderer.submit_render_static(&test_camera()).expect("render should submit");
     drop(request);
     drop(renderer);
 }

--- a/tests/style_geojson_layers.rs
+++ b/tests/style_geojson_layers.rs
@@ -16,13 +16,7 @@ fn fixture_path(name: &str) -> PathBuf {
 }
 
 fn camera(zoom: f64) -> CameraUpdate {
-    CameraUpdate {
-        center: Some(LatLng { lat: 0.0, lng: 0.0 }),
-        zoom: Some(zoom),
-        bearing: Some(0.0),
-        pitch: Some(0.0),
-        ..Default::default()
-    }
+    CameraUpdate::new().center(LatLng { lat: 0.0, lng: 0.0 }).zoom(zoom).bearing(0.0).pitch(0.0)
 }
 
 fn renderer() -> ImageRenderer<Static> {

--- a/tests/style_geojson_layers.rs
+++ b/tests/style_geojson_layers.rs
@@ -32,8 +32,7 @@ fn renderer() -> ImageRenderer<Static> {
         .build_static_renderer();
 
     renderer.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
-    let background =
-        renderer.render_static(&camera(0.0)).expect("background style should render");
+    let background = renderer.render_static(&camera(0.0)).expect("background style should render");
     assert_eq!(background.as_image().width(), 128);
     renderer
 }
@@ -91,8 +90,7 @@ where
 {
     let started = Instant::now();
     loop {
-        let frame =
-            renderer.render_static(&camera(1.0)).expect("GeoJSON layers should render");
+        let frame = renderer.render_static(&camera(1.0)).expect("GeoJSON layers should render");
         if predicate(&frame) {
             break frame;
         }

--- a/tests/style_geojson_layers.rs
+++ b/tests/style_geojson_layers.rs
@@ -5,14 +5,24 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use maplibre_native::{
-    CircleLayer, Color, FillLayer, GeoJson, GeoJsonSource, Image, ImageRenderer,
-    ImageRendererBuilder, LineCap, LineJoin, LineLayer, Static, Style,
+    CameraUpdate, CircleLayer, Color, FillLayer, GeoJson, GeoJsonSource, Image, ImageRenderer,
+    ImageRendererBuilder, LatLng, LineCap, LineJoin, LineLayer, Static, Style,
 };
 
 const RENDER_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn fixture_path(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name)
+}
+
+fn camera(zoom: f64) -> CameraUpdate {
+    CameraUpdate {
+        center: Some(LatLng { lat: 0.0, lng: 0.0 }),
+        zoom: Some(zoom),
+        bearing: Some(0.0),
+        pitch: Some(0.0),
+        ..Default::default()
+    }
 }
 
 fn renderer() -> ImageRenderer<Static> {
@@ -23,7 +33,7 @@ fn renderer() -> ImageRenderer<Static> {
 
     renderer.load_style_from_path(fixture_path("test-style.json")).expect("test style should load");
     let background =
-        renderer.render_static(0.0, 0.0, 0.0, 0.0, 0.0).expect("background style should render");
+        renderer.render_static(&camera(0.0)).expect("background style should render");
     assert_eq!(background.as_image().width(), 128);
     renderer
 }
@@ -82,7 +92,7 @@ where
     let started = Instant::now();
     loop {
         let frame =
-            renderer.render_static(0.0, 0.0, 1.0, 0.0, 0.0).expect("GeoJSON layers should render");
+            renderer.render_static(&camera(1.0)).expect("GeoJSON layers should render");
         if predicate(&frame) {
             break frame;
         }


### PR DESCRIPTION
Bind MapLibre Native's `CameraOptions` and `Map::cameraForLatLngBounds`, enabling static image rendering fitted to a geographic bbox.

- Add `CameraUpdate`, `LatLng`, `LatLngBounds`, and `EdgeInsets`
    - Remove the `X`/`Y`/`Width`/`Height`/`Latitude`/`Longitude` newtypes
- Add `render_static` / `submit_render_static` taking `&CameraUpdate` instead of positional `(lat, lon, zoom, bearing, pitch)`
- Add `camera_for_bounds`, which computes a `CameraUpdate` via `Map::cameraForLatLngBounds`
- Add `update_camera` for `ImageRenderer<Continuous>`, replacing `set_camera`