### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.6.1...v0.7.0) - 2026-05-30
+
+### Added
+
+- *(renderer)* [**breaking**] add camera APIs and bounds-fit rendering capability ([#204](https://github.com/maplibre/maplibre-native-rs/pull/204))
+
 ## [0.6.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.6.0...v0.6.1) - 2026-05-26
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.6.1"
+version = "0.7.0"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -80,7 +80,7 @@ geojson = "1.0.0"
 image = "0.25"
 insta = "1.43"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.6.1" }
+maplibre_native = { path = ".", version = "0.7.0" }
 serde_json = "1.0"
 tar = "0.4.44"
 thiserror = "2.0.16"


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.6.1 -> 0.7.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.6.1...v0.7.0) - 2026-05-30

### Added

- *(renderer)* [**breaking**] add camera APIs and bounds-fit rendering capability ([#204](https://github.com/maplibre/maplibre-native-rs/pull/204))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).