### PR TITLE
fix(ci): use fetch-depth: 0 so release-plz sees full history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 defaults:
@@ -30,7 +30,7 @@ jobs:
       - run: echo "MLN_CORE_LIBRARY_USE_AMALGAM=0" >> $GITHUB_ENV
       - run: rustup update stable && rustup default stable && rustup component add rustfmt && rustup component add clippy
       - uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
-        with: { tool: 'just' }
+        with: { tool: "just" }
       - run: just env-info install-dependencies 'vulkan'
       - run: just ci-lint
   test:
@@ -75,7 +75,7 @@ jobs:
       - if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
-        with: { tool: 'just' }
+        with: { tool: "just" }
       - run: echo "MLN_PRECOMPILE=${{ matrix.precompiled }}" >> $GITHUB_ENV
       - run: echo "MLN_CORE_LIBRARY_USE_AMALGAM=${{ matrix.amalgam }}" >> $GITHUB_ENV
       - run: just env-info install-dependencies '${{ matrix.backend }}'
@@ -129,7 +129,7 @@ jobs:
       - if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
-        with: { tool: 'just' }
+        with: { tool: "just" }
       - run: echo "MLN_PRECOMPILE=${{ matrix.precompiled }}" >> $GITHUB_ENV
       - run: echo "MLN_CORE_LIBRARY_USE_AMALGAM=${{ matrix.amalgam }}" >> $GITHUB_ENV
       - run: just env-info install-dependencies '${{ matrix.backend }}'
@@ -146,15 +146,15 @@ jobs:
           toolchain: ${{ steps.msrv.outputs.value }}
       - name: Run CI tests (MSRV, Linux OpenGL via Xvfb)
         if: startsWith(matrix.runs-on, 'ubuntu') && matrix.backend == 'opengl'
-        run: xvfb-run -a --server-args="-screen 0 1280x1024x24" just ci_mode=0 ci-test-msrv ${{ matrix.backend }}  # Ignore warnings in MSRV
+        run: xvfb-run -a --server-args="-screen 0 1280x1024x24" just ci_mode=0 ci-test-msrv ${{ matrix.backend }} # Ignore warnings in MSRV
       - name: Run CI tests (MSRV)
         if: ${{ !(startsWith(matrix.runs-on, 'ubuntu') && matrix.backend == 'opengl') }}
-        run: just ci_mode=0 ci-test-msrv ${{ matrix.backend }}  # Ignore warnings in MSRV
+        run: just ci_mode=0 ci-test-msrv ${{ matrix.backend }} # Ignore warnings in MSRV
 
   # This final step is needed to mark the whole workflow as successful
   # Don't change its name - it is used by the merge protection rules
   ci-passed:
-    needs: [ lint, test, test-msrv ]
+    needs: [lint, test, test-msrv]
     if: always()
     runs-on: ubuntu-latest
     permissions: {}
@@ -166,7 +166,7 @@ jobs:
 
   # Release unpublished packages or create a PR with changes
   release-plz:
-    needs: [ ci-passed ]
+    needs: [ci-passed]
     if: |
       always()
       && needs.ci-passed.result == 'success'
@@ -184,7 +184,9 @@ jobs:
       MLN_PRECOMPILE: 1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with: { persist-credentials: false }
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Publish to crates.io if crate's version is newer
         uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db # v0.5.129

--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -5,6 +5,7 @@
 #include <mbgl/style/image.hpp>
 #include <mbgl/style/layer.hpp>
 #include <mbgl/map/map.hpp>
+#include <mbgl/map/map_observer.hpp>
 #include <mbgl/map/map_options.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/source.hpp>
@@ -14,9 +15,6 @@
 #include <mbgl/util/tile_server_options.hpp>
 #include <mbgl/util/size.hpp>
 #include "mbgl/storage/resource_options.hpp"
-#if !defined(__APPLE__) || defined(MLN_DARWIN_USE_LIBUV)
-#include <uv.h>
-#endif
 #include <cassert>
 #include <memory>
 #include <optional>
@@ -24,8 +22,16 @@
 #include <stdexcept>
 #include "rust/cxx.h"
 #include "rust_log_observer.h"
-#include <mbgl/map/map_observer.hpp>
 #include "map_observer.h"
+
+#if (!defined(__APPLE__) || defined(MLN_DARWIN_USE_LIBUV)) && __has_include(<uv.h>)
+#include <uv.h>
+#elif !defined(__APPLE__) || defined(MLN_DARWIN_USE_LIBUV)
+struct uv_loop_s;
+using uv_loop_t = uv_loop_s;
+enum uv_run_mode { UV_RUN_DEFAULT = 0, UV_RUN_ONCE, UV_RUN_NOWAIT };
+extern "C" int uv_run(uv_loop_t*, uv_run_mode);
+#endif
 
 namespace mln {
 namespace bridge {


### PR DESCRIPTION
`fetch-depth: 0` was not set, so release-plz only saw HEAD and could generate broken release PRs. See: https://release-plz.dev/docs/github/quickstart#3-setup-the-workflow

(It also fixes `MLN_PRECOMPILE=1` builds, which failed because `uv.h` was treated as a hard dependency.)
