### PR TITLE
feat(style): add mutable source refs for GeoJSON updates

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -92,15 +92,41 @@ impl std::fmt::Debug for geojson::GeoJson {
 /// This module provides C++/Rust interoperability for various source types.
 /// Currently supports GeoJSON sources, with extensibility for additional source types.
 pub mod sources {
+    /// MapLibre style-spec source type.
+    /// Rust mirror of `mbgl::style::SourceType`.
+    #[derive(Debug)]
+    #[namespace = "mbgl::style"]
+    enum SourceType {
+        /// Vector tile source.
+        Vector,
+        /// Raster tile source.
+        Raster,
+        /// Raster DEM source.
+        RasterDEM,
+        /// GeoJSON source.
+        GeoJSON,
+        /// Video source.
+        Video,
+        /// Annotations source.
+        Annotations,
+        /// Image source.
+        Image,
+        /// Custom vector source.
+        CustomVector,
+    }
+
     #[namespace = "mbgl::style"]
     extern "C++" {
         include!("mbgl/style/source.hpp");
         include!("mbgl/style/sources/geojson_source.hpp");
+        include!("mbgl/style/types.hpp");
         // Opaque types
         /// Base class for all MapLibre Native style sources.
         type Source;
         /// A GeoJSON source for MapLibre rendering.
         type GeoJSONSource;
+        /// `mbgl::style::SourceType`
+        type SourceType;
     }
 
     #[namespace = "mln::bridge::geojson"]
@@ -116,6 +142,22 @@ pub mod sources {
     unsafe extern "C++" {
         include!("sources/sources.h");
 
+        /// A non-owning handle to a style-owned source.
+        type SourceHandle;
+        /// A non-owning handle to a style-owned GeoJSON source.
+        type GeoJSONSourceHandle;
+
+        /// Returns the source ID.
+        fn sourceId(self: &SourceHandle) -> String;
+        /// Returns the MapLibre style-spec source type.
+        fn sourceType(self: &SourceHandle) -> SourceType;
+        /// Downcasts this handle to a GeoJSON source handle, if it is one.
+        fn asGeoJson(self: &SourceHandle) -> UniquePtr<GeoJSONSourceHandle>;
+        /// Returns the GeoJSON source ID.
+        fn sourceId(self: &GeoJSONSourceHandle) -> String;
+        /// Sets the GeoJSON data for this source.
+        fn setGeoJson(self: Pin<&mut GeoJSONSourceHandle>, geojson: &CxxGeoJson);
+
         /// Upcasts a GeoJSON source handle to the base `Source` type.
         fn geojson_into_source(source: UniquePtr<GeoJSONSource>) -> UniquePtr<Source>;
     }
@@ -127,8 +169,13 @@ pub mod sources {
         /// Creates a new GeoJSON source with the given ID.
         fn create(id: &str) -> UniquePtr<GeoJSONSource>;
         /// Sets the GeoJSON data for the source.
-        fn setGeoJson(source: &UniquePtr<GeoJSONSource>, geojson: &CxxGeoJson);
+        fn setGeoJson(source: Pin<&mut GeoJSONSource>, geojson: &CxxGeoJson);
     }
+
+    // Generate `UniquePtr<SourceHandle>` support. cxx emits it only in the
+    // module that uses the type in a signature, but `SourceHandle` is only
+    // returned via the `ffi` module's alias, so request it explicitly here.
+    impl UniquePtr<SourceHandle> {}
 }
 
 impl std::fmt::Debug for sources::GeoJSONSource {
@@ -934,6 +981,13 @@ pub mod ffi {
         type Layer = super::layers::Layer;
     }
 
+    #[namespace = "mln::bridge::style::sources"]
+    extern "C++" {
+        /// Source handle opaque type.
+        #[rust_name = "CxxSourceHandle"]
+        type SourceHandle = super::sources::SourceHandle;
+    }
+
     // Declarations for Rust with implementations in C++
     unsafe extern "C++" {
         include!("map_renderer.h");
@@ -1024,6 +1078,11 @@ pub mod ffi {
             self: Pin<&mut MapRenderer>,
             source: UniquePtr<CxxSource>,
         ) -> Result<()>;
+        /// Gets a mutable reference to a style source by ID.
+        fn style_get_source_mut(
+            self: Pin<&mut MapRenderer>,
+            id: &str,
+        ) -> UniquePtr<CxxSourceHandle>;
         /// Removes a source from the style by ID.
         fn style_remove_source(self: Pin<&mut MapRenderer>, id: &str);
         /// Adds a layer to the style, optionally before an existing layer

--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -23,6 +23,7 @@
 #include "rust/cxx.h"
 #include "rust_log_observer.h"
 #include "map_observer.h"
+#include "sources/sources.h"
 
 #if (!defined(__APPLE__) || defined(MLN_DARWIN_USE_LIBUV)) && __has_include(<uv.h>)
 #include <uv.h>
@@ -146,6 +147,14 @@ public:
 
     void style_add_source(std::unique_ptr<mbgl::style::Source> source) {
         map->getStyle().addSource(std::move(source));
+    }
+
+    std::unique_ptr<mln::bridge::style::sources::SourceHandle> style_get_source_mut(rust::Str id) {
+        auto* source = map->getStyle().getSource(std::string(id));
+        if (!source) {
+            return nullptr;
+        }
+        return std::make_unique<mln::bridge::style::sources::SourceHandle>(source);
     }
 
     void style_remove_source(rust::Str id) {

--- a/src/cpp/sources/sources.cpp
+++ b/src/cpp/sources/sources.cpp
@@ -2,9 +2,34 @@
 #include "geojson/geojson.h"
 #include <mbgl/style/source.hpp>
 #include <mbgl/style/sources/geojson_source.hpp>
+#include <mbgl/style/types.hpp>
 #include <memory>
 
 namespace mln::bridge::style::sources {
+    rust::String SourceHandle::sourceId() const {
+        return source->getID();
+    }
+
+    mbgl::style::SourceType SourceHandle::sourceType() const {
+        return source->getType();
+    }
+
+    std::unique_ptr<GeoJSONSourceHandle> SourceHandle::asGeoJson() const {
+        auto* geojson = source->as<mbgl::style::GeoJSONSource>();
+        if (!geojson) {
+            return nullptr;
+        }
+        return std::make_unique<GeoJSONSourceHandle>(geojson);
+    }
+
+    rust::String GeoJSONSourceHandle::sourceId() const {
+        return source->getID();
+    }
+
+    void GeoJSONSourceHandle::setGeoJson(const mln::bridge::geojson::GeoJson& geojson) {
+        source->setGeoJSON(geojson.get());
+    }
+
     std::unique_ptr<mbgl::style::Source> geojson_into_source(
         std::unique_ptr<mbgl::style::GeoJSONSource> source) {
         return source;
@@ -16,8 +41,8 @@ namespace mln::bridge::style::sources::geojson {
         return std::make_unique<mbgl::style::GeoJSONSource>(std::string(id));
     }
 
-    void setGeoJson(const std::unique_ptr<mbgl::style::GeoJSONSource>& source,
+    void setGeoJson(mbgl::style::GeoJSONSource& source,
                     const mln::bridge::geojson::GeoJson& geojson) {
-        source->setGeoJSON(geojson.get());
+        source.setGeoJSON(geojson.get());
     }
 }

--- a/src/cpp/sources/sources.h
+++ b/src/cpp/sources/sources.h
@@ -1,26 +1,61 @@
-#include <memory>
+#pragma once
+
 #include "rust/cxx.h"
+#include <cstdint>
+#include <memory>
+#include <string>
 
 namespace mbgl::style {
-    class Source;
-    class GeoJSONSource;
-}
+class Source;
+class GeoJSONSource;
+enum class SourceType : ::std::uint8_t;
+} // namespace mbgl::style
 
 namespace mln::bridge::geojson {
-    class GeoJson;
+class GeoJson;
 }
 
 namespace mln::bridge::style::sources {
-    // Upcasts derived `mbgl::style::Source` handles to the base type so that
-    // `Style::addSource(unique_ptr<Source>)` can be invoked through a single
-    // bridge function regardless of the concrete source type.
-    std::unique_ptr<mbgl::style::Source> geojson_into_source(
-        std::unique_ptr<mbgl::style::GeoJSONSource> source);
-}
+class GeoJSONSourceHandle;
+
+// Non-owning handle to a source owned by the style.
+// Valid only while the owning style outlives it;
+// the Rust side ties this to a `&mut StyleRef`.
+class SourceHandle {
+public:
+  explicit SourceHandle(mbgl::style::Source *source_) : source(source_) {}
+
+  rust::String sourceId() const;
+  mbgl::style::SourceType sourceType() const;
+  std::unique_ptr<GeoJSONSourceHandle> asGeoJson() const;
+
+private:
+  mbgl::style::Source *source;
+};
+
+// Non-owning handle to a GeoJSON source owned by the style.
+class GeoJSONSourceHandle {
+public:
+  explicit GeoJSONSourceHandle(mbgl::style::GeoJSONSource *source_)
+      : source(source_) {}
+
+  rust::String sourceId() const;
+  void setGeoJson(const mln::bridge::geojson::GeoJson &geojson);
+
+private:
+  mbgl::style::GeoJSONSource *source;
+};
+
+// Upcasts derived `mbgl::style::Source` handles to the base type so that
+// `Style::addSource(unique_ptr<Source>)` can be invoked through a single
+// bridge function regardless of the concrete source type.
+std::unique_ptr<mbgl::style::Source>
+geojson_into_source(std::unique_ptr<mbgl::style::GeoJSONSource> source);
+} // namespace mln::bridge::style::sources
 
 namespace mln::bridge::style::sources::geojson {
-    std::unique_ptr<mbgl::style::GeoJSONSource> create(rust::Str id);
+std::unique_ptr<mbgl::style::GeoJSONSource> create(rust::Str id);
 
-    void setGeoJson(const std::unique_ptr<mbgl::style::GeoJSONSource>& source,
-                    const mln::bridge::geojson::GeoJson& geojson);
-}
+void setGeoJson(mbgl::style::GeoJSONSource &source,
+                const mln::bridge::geojson::GeoJson &geojson);
+} // namespace mln::bridge::style::sources::geojson

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -18,5 +18,8 @@ pub use layers::{
     AnyLayer, CircleLayer, FillLayer, Layer, LayerId, LineCap, LineJoin, LineLayer, OpaqueLayer,
     SymbolAnchor, SymbolLayer,
 };
-pub use sources::{GeoJsonSource, Source, SourceId};
+pub use sources::{
+    GeoJsonSource, GeoJsonSourceRefMut, OpaqueSourceRefMut, Source, SourceId, SourceRefMut,
+    SourceType,
+};
 pub use style_ref::StyleRef;

--- a/src/style/sources/geojson.rs
+++ b/src/style/sources/geojson.rs
@@ -1,9 +1,10 @@
 use std::fmt;
+use std::marker::PhantomData;
 
 use cxx::UniquePtr;
 
 use crate::bridge::sources;
-use crate::style::GeoJson;
+use crate::style::{GeoJson, SourceId};
 
 /// A GeoJSON source for rendering geographic data.
 pub struct GeoJsonSource {
@@ -24,7 +25,7 @@ impl GeoJsonSource {
 
     /// Sets the GeoJSON data for this source.
     pub fn set_geojson(&mut self, geojson: &GeoJson) {
-        sources::setGeoJson(&self.source, geojson.as_inner());
+        sources::setGeoJson(self.source.pin_mut(), geojson.as_inner());
     }
 
     pub(crate) fn into_inner(self) -> UniquePtr<sources::GeoJSONSource> {
@@ -38,5 +39,35 @@ impl fmt::Debug for GeoJsonSource {
             .field("source_id", &self.source_id)
             .field("Pointer", &self.source.as_ptr())
             .finish()
+    }
+}
+
+/// A mutable reference to a GeoJSON source owned by the current style.
+pub struct GeoJsonSourceRefMut<'a> {
+    source: UniquePtr<sources::GeoJSONSourceHandle>,
+    _marker: PhantomData<&'a mut ()>,
+    _not_send: PhantomData<*mut ()>,
+}
+
+impl GeoJsonSourceRefMut<'_> {
+    pub(crate) fn new(source: UniquePtr<sources::GeoJSONSourceHandle>) -> Self {
+        Self { source, _marker: PhantomData, _not_send: PhantomData }
+    }
+
+    /// Returns the source ID.
+    #[must_use]
+    pub fn source_id(&self) -> SourceId {
+        SourceId::new(self.source.sourceId())
+    }
+
+    /// Sets the GeoJSON data for this source.
+    pub fn set_geojson(&mut self, geojson: &GeoJson) {
+        self.source.pin_mut().setGeoJson(geojson.as_inner());
+    }
+}
+
+impl fmt::Debug for GeoJsonSourceRefMut<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GeoJsonSourceRefMut").field("source_id", &self.source_id()).finish()
     }
 }

--- a/src/style/sources/mod.rs
+++ b/src/style/sources/mod.rs
@@ -1,7 +1,9 @@
 mod geojson;
 mod id;
+mod refs;
 mod traits;
 
-pub use geojson::GeoJsonSource;
+pub use geojson::{GeoJsonSource, GeoJsonSourceRefMut};
 pub use id::SourceId;
+pub use refs::{OpaqueSourceRefMut, SourceRefMut, SourceType};
 pub use traits::Source;

--- a/src/style/sources/refs.rs
+++ b/src/style/sources/refs.rs
@@ -1,0 +1,132 @@
+use std::fmt;
+use std::marker::PhantomData;
+
+use cxx::UniquePtr;
+
+use super::geojson::GeoJsonSourceRefMut;
+use crate::bridge::sources;
+use crate::SourceId;
+
+/// MapLibre style-spec source type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum SourceType {
+    /// Vector tile source.
+    Vector,
+    /// Raster tile source.
+    Raster,
+    /// Raster DEM source.
+    RasterDem,
+    /// GeoJSON source.
+    GeoJson,
+    /// Video source.
+    Video,
+    /// Annotations source.
+    Annotations,
+    /// Image source.
+    Image,
+    /// Custom vector source.
+    CustomVector,
+    /// Source type not known by this crate version.
+    Unknown,
+}
+
+impl From<sources::SourceType> for SourceType {
+    fn from(value: sources::SourceType) -> Self {
+        match value {
+            sources::SourceType::Vector => Self::Vector,
+            sources::SourceType::Raster => Self::Raster,
+            sources::SourceType::RasterDEM => Self::RasterDem,
+            sources::SourceType::GeoJSON => Self::GeoJson,
+            sources::SourceType::Video => Self::Video,
+            sources::SourceType::Annotations => Self::Annotations,
+            sources::SourceType::Image => Self::Image,
+            sources::SourceType::CustomVector => Self::CustomVector,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// A mutable reference to a source owned by the current style.
+#[non_exhaustive]
+pub enum SourceRefMut<'a> {
+    /// A GeoJSON source.
+    GeoJson(GeoJsonSourceRefMut<'a>),
+    /// A source type that does not have a typed Rust reference yet.
+    Opaque(OpaqueSourceRefMut<'a>),
+}
+
+impl SourceRefMut<'_> {
+    /// Wraps a raw FFI handle.
+    /// The caller must ensure the returned reference's
+    /// lifetime stays bounded by the borrow of the owning style.
+    pub(crate) fn from_ffi(source: UniquePtr<sources::SourceHandle>) -> Option<Self> {
+        let geojson = source.as_ref()?.asGeoJson();
+        Some(if geojson.is_null() {
+            Self::Opaque(OpaqueSourceRefMut::new(source))
+        } else {
+            Self::GeoJson(GeoJsonSourceRefMut::new(geojson))
+        })
+    }
+
+    /// Returns the source ID.
+    #[must_use]
+    pub fn source_id(&self) -> SourceId {
+        match self {
+            Self::GeoJson(source) => source.source_id(),
+            Self::Opaque(source) => source.source_id(),
+        }
+    }
+
+    /// Returns the MapLibre style-spec source type.
+    #[must_use]
+    pub fn source_type(&self) -> SourceType {
+        match self {
+            Self::GeoJson(_) => SourceType::GeoJson,
+            Self::Opaque(source) => source.source_type(),
+        }
+    }
+}
+
+impl fmt::Debug for SourceRefMut<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SourceRefMut")
+            .field("source_id", &self.source_id())
+            .field("source_type", &self.source_type())
+            .finish_non_exhaustive()
+    }
+}
+
+/// A mutable reference to a style-owned source without a typed Rust wrapper.
+pub struct OpaqueSourceRefMut<'a> {
+    source: UniquePtr<sources::SourceHandle>,
+    _marker: PhantomData<&'a mut ()>,
+    _not_send: PhantomData<*mut ()>,
+}
+
+impl OpaqueSourceRefMut<'_> {
+    fn new(source: UniquePtr<sources::SourceHandle>) -> Self {
+        Self { source, _marker: PhantomData, _not_send: PhantomData }
+    }
+
+    /// Returns the source ID.
+    #[must_use]
+    pub fn source_id(&self) -> SourceId {
+        SourceId::new(self.source.sourceId())
+    }
+
+    /// Returns the MapLibre style-spec source type.
+    #[must_use]
+    pub fn source_type(&self) -> SourceType {
+        self.source.sourceType().into()
+    }
+}
+
+impl fmt::Debug for OpaqueSourceRefMut<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpaqueSourceRefMut")
+            .field("source_id", &self.source_id())
+            .field("source_type", &self.source_type())
+            .finish()
+    }
+}

--- a/src/style/style_ref.rs
+++ b/src/style/style_ref.rs
@@ -1,7 +1,7 @@
 use image::DynamicImage;
 
 use crate::bridge::ffi;
-use crate::{ImageId, ImageRenderer, Layer, LayerId, Source, SourceId, StyleError};
+use crate::{ImageId, ImageRenderer, Layer, LayerId, Source, SourceId, SourceRefMut, StyleError};
 
 /// A mutable reference to the renderer's current map style.
 #[derive(Debug)]
@@ -56,6 +56,15 @@ impl<'a, S> StyleRef<'a, S> {
         let source_id = SourceId::new(source.source_id().to_owned());
         self.image_renderer.instance.pin_mut().style_add_source(source.into_source())?;
         Ok(source_id)
+    }
+
+    /// Returns a mutable reference to a source in the current map style.
+    ///
+    /// Returns `None` if `source_id` does not match an existing source.
+    pub fn source_mut(&mut self, source_id: impl AsRef<str>) -> Option<SourceRefMut<'_>> {
+        SourceRefMut::from_ffi(
+            self.image_renderer.instance.pin_mut().style_get_source_mut(source_id.as_ref()),
+        )
     }
 
     /// Adds a new layer and returns its stable layer ID.

--- a/tests/style_geojson_layers.rs
+++ b/tests/style_geojson_layers.rs
@@ -2,14 +2,11 @@
 
 use std::num::NonZeroU32;
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
 
 use maplibre_native::{
-    CameraUpdate, CircleLayer, Color, FillLayer, GeoJson, GeoJsonSource, Image, ImageRenderer,
-    ImageRendererBuilder, LatLng, LineCap, LineJoin, LineLayer, Static,
+    CameraUpdate, CircleLayer, Color, FillLayer, GeoJson, GeoJsonSource, ImageRenderer,
+    ImageRendererBuilder, LatLng, LineCap, LineJoin, LineLayer, SourceRefMut, Static,
 };
-
-const RENDER_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn fixture_path(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(name)
@@ -73,6 +70,15 @@ fn overlay_geojson() -> GeoJson {
     .expect("inline GeoJSON should parse")
 }
 
+fn empty_geojson() -> GeoJson {
+    r#"{
+        "type": "FeatureCollection",
+        "features": []
+    }"#
+    .parse::<GeoJson>()
+    .expect("inline GeoJSON should parse")
+}
+
 fn has_non_background_pixel(image: &image::RgbaImage) -> bool {
     image.pixels().any(|pixel| {
         let [red, green, blue, alpha] = pixel.0;
@@ -80,21 +86,15 @@ fn has_non_background_pixel(image: &image::RgbaImage) -> bool {
     })
 }
 
-fn render_until<F>(renderer: &mut ImageRenderer<Static>, predicate: F) -> Image
-where
-    F: Fn(&Image) -> bool,
-{
-    let started = Instant::now();
-    loop {
-        let frame = renderer.render_static(&camera(1.0)).expect("GeoJSON layers should render");
-        if predicate(&frame) {
-            break frame;
-        }
-        assert!(
-            started.elapsed() < RENDER_TIMEOUT,
-            "GeoJSON layers did not draw expected pixels within {RENDER_TIMEOUT:?}",
-        );
-    }
+fn has_green_pixel(image: &image::RgbaImage) -> bool {
+    image.pixels().any(|pixel| {
+        let [red, green, _blue, alpha] = pixel.0;
+        alpha > 0 && green > red.saturating_add(20)
+    })
+}
+
+fn render(renderer: &mut ImageRenderer<Static>) -> image::RgbaImage {
+    renderer.render_static(&camera(1.0)).expect("static render should succeed").as_image().clone()
 }
 
 #[test]
@@ -128,10 +128,45 @@ fn geojson_source_renders_circle_line_and_fill_layers() {
     circle.set_circle_stroke_width(2.0);
     style.add_layer(circle).expect("circle layer should be added");
 
-    let image = render_until(&mut renderer, |image| has_non_background_pixel(image.as_image()));
+    let image = render(&mut renderer);
+    assert!(has_non_background_pixel(&image), "GeoJSON layers should draw visible pixels");
+    assert_eq!(image.width(), 128);
+    assert_eq!(image.height(), 128);
+}
 
-    assert_eq!(image.as_image().width(), 128);
-    assert_eq!(image.as_image().height(), 128);
+#[test]
+fn geojson_source_ref_mut_updates_existing_source() {
+    let mut renderer = renderer();
+
+    let mut source = GeoJsonSource::new("dynamic-source");
+    let geojson = overlay_geojson();
+    source.set_geojson(&geojson);
+
+    {
+        let mut style = renderer.style();
+        let source_id = style.add_source(source).expect("GeoJSON source should be added");
+
+        let mut fill = FillLayer::new("dynamic-fill", &source_id);
+        fill.set_fill_color(Color::rgb(0.0, 1.0, 0.0));
+        style.add_layer(fill).expect("fill layer should be added");
+    }
+
+    let image = render(&mut renderer);
+    assert!(has_green_pixel(&image), "fill should render green before the update");
+
+    {
+        let mut style = renderer.style();
+        let Some(SourceRefMut::GeoJson(mut source)) = style.source_mut("dynamic-source") else {
+            panic!("dynamic-source should be a GeoJSON source");
+        };
+        assert_eq!(source.source_id().as_str(), "dynamic-source");
+        source.set_geojson(&empty_geojson());
+    }
+
+    let image = render(&mut renderer);
+    assert!(!has_green_pixel(&image), "green should disappear after clearing the source");
+    assert_eq!(image.width(), 128);
+    assert_eq!(image.height(), 128);
 }
 
 #[test]
@@ -187,7 +222,8 @@ fn layer_management_methods_smoke_test() {
     let removable_layer = style.add_layer(circle).expect("circle layer should be re-added");
     assert_eq!(removable_layer.as_str(), "removable-layer");
 
-    let image = render_until(&mut renderer, |image| has_non_background_pixel(image.as_image()));
-    assert_eq!(image.as_image().width(), 128);
-    assert_eq!(image.as_image().height(), 128);
+    let image = render(&mut renderer);
+    assert!(has_non_background_pixel(&image), "re-added layer should draw visible pixels");
+    assert_eq!(image.width(), 128);
+    assert_eq!(image.height(), 128);
 }


### PR DESCRIPTION
Adds an API to get and update existing style sources.

- Add `StyleRef::source_mut`
- Add `SourceRefMut` for style-owned sources
- Add `GeoJsonSourceRefMut` for updating existing GeoJSON sources

For now, this is focused on `GeoJsonSource`, which should make it easier to build dynamic overlays without recreating sources and layers.