### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.7.0...v0.8.0) - 2026-06-03
+
+### Added
+
+- *(renderer)* add camera_for_geojson and camera_for_lat_lngs ([#219](https://github.com/maplibre/maplibre-native-rs/pull/219))
+- *(style)* support pixel ratio for style images ([#220](https://github.com/maplibre/maplibre-native-rs/pull/220))
+- *(style)* return the removed layer from remove_layer ([#218](https://github.com/maplibre/maplibre-native-rs/pull/218))
+
+### Other
+
+- *(ci)* Fix update-maplibre-native workflow ([#216](https://github.com/maplibre/maplibre-native-rs/pull/216))
+
 ## [0.7.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.6.1...v0.7.0) - 2026-06-01
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.7.0"
+version = "0.8.0"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -80,7 +80,7 @@ geojson = "1.0.0"
 image = "0.25"
 insta = "1.43"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.7.0" }
+maplibre_native = { path = ".", version = "0.8.0" }
 serde_json = "1.0"
 tar = "0.4.44"
 thiserror = "2.0.16"


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)

### ⚠ `maplibre_native` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/method_parameter_count_changed.ron

Failed in:
  maplibre_native::StyleRef::add_image takes 3 parameters in /tmp/.tmpPmgr1R/maplibre_native/src/style/style_ref.rs:25, but now takes 4 parameters in /tmp/.tmp0YISMB/maplibre-native-rs/src/style/style_ref.rs:25
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.7.0...v0.8.0) - 2026-06-03

### Added

- *(renderer)* add camera_for_geojson and camera_for_lat_lngs ([#219](https://github.com/maplibre/maplibre-native-rs/pull/219))
- *(style)* support pixel ratio for style images ([#220](https://github.com/maplibre/maplibre-native-rs/pull/220))
- *(style)* return the removed layer from remove_layer ([#218](https://github.com/maplibre/maplibre-native-rs/pull/218))

### Other

- *(ci)* Fix update-maplibre-native workflow ([#216](https://github.com/maplibre/maplibre-native-rs/pull/216))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).