### PR TITLE
feat(style): return the removed layer from remove_layer

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -241,10 +241,8 @@ pub mod layers {
         include!("layers/layers.h");
 
         /// Returns the layer's ID (the style-spec `"id"` field).
-        #[cfg(feature = "json")]
         fn layer_id(layer: &UniquePtr<Layer>) -> String;
         /// Returns the layer's type name (e.g. `"circle"`, `"fill"`).
-        #[cfg(feature = "json")]
         fn layer_type(layer: &UniquePtr<Layer>) -> String;
 
         /// Upcasts a circle layer handle to the base `Layer` type.
@@ -261,16 +259,12 @@ pub mod layers {
         fn symbol_into_layer(layer: UniquePtr<SymbolLayer>) -> UniquePtr<Layer>;
 
         /// Downcasts a base layer handle to a circle layer. Returns null on type mismatch.
-        #[cfg(feature = "json")]
         fn try_into_circle(layer: UniquePtr<Layer>) -> UniquePtr<CircleLayer>;
         /// Downcasts a base layer handle to a fill layer. Returns null on type mismatch.
-        #[cfg(feature = "json")]
         fn try_into_fill(layer: UniquePtr<Layer>) -> UniquePtr<FillLayer>;
         /// Downcasts a base layer handle to a line layer. Returns null on type mismatch.
-        #[cfg(feature = "json")]
         fn try_into_line(layer: UniquePtr<Layer>) -> UniquePtr<LineLayer>;
         /// Downcasts a base layer handle to a symbol layer. Returns null on type mismatch.
-        #[cfg(feature = "json")]
         fn try_into_symbol(layer: UniquePtr<Layer>) -> UniquePtr<SymbolLayer>;
 
         /// Creates a new circle layer.
@@ -1033,8 +1027,8 @@ pub mod ffi {
             layer: UniquePtr<CxxLayer>,
             before_id: &str,
         ) -> Result<()>;
-        /// Removes a layer from the style by ID.
-        fn style_remove_layer(self: Pin<&mut MapRenderer>, id: &str);
+        /// Removes a layer from the style by ID and returns it.
+        fn style_remove_layer(self: Pin<&mut MapRenderer>, id: &str) -> UniquePtr<CxxLayer>;
     }
 
     // Declarations for C++ with implementations in Rust

--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -159,8 +159,8 @@ public:
             before_id.empty() ? std::nullopt : std::optional<std::string>{std::string(before_id)});
     }
 
-    void style_remove_layer(rust::Str id) {
-        map->getStyle().removeLayer(std::string(id));
+    std::unique_ptr<mbgl::style::Layer> style_remove_layer(rust::Str id) {
+        return map->getStyle().removeLayer(std::string(id));
     }
 
     void style_load_from_url(const rust::Str styleUrl) {

--- a/src/style/layers/any.rs
+++ b/src/style/layers/any.rs
@@ -65,6 +65,27 @@ pub enum AnyLayer {
 }
 
 impl AnyLayer {
+    pub(crate) fn from_layer_ptr(layer: UniquePtr<ffi::CxxLayer>) -> Option<Self> {
+        if layer.is_null() {
+            return None;
+        }
+
+        let layer_id = layers::layer_id(&layer);
+        let layer_type = layers::layer_type(&layer);
+
+        Some(match layer_type.as_str() {
+            "circle" => {
+                Self::Circle(CircleLayer::from_ffi_parts(layer_id, layers::try_into_circle(layer)))
+            }
+            "fill" => Self::Fill(FillLayer::from_ffi_parts(layer_id, layers::try_into_fill(layer))),
+            "line" => Self::Line(LineLayer::from_ffi_parts(layer_id, layers::try_into_line(layer))),
+            "symbol" => {
+                Self::Symbol(SymbolLayer::from_ffi_parts(layer_id, layers::try_into_symbol(layer)))
+            }
+            _ => Self::Opaque(OpaqueLayer { layer_id, layer_type, layer }),
+        })
+    }
+
     /// Parses a single style-spec layer object from a JSON string.
     ///
     /// # Errors
@@ -91,20 +112,7 @@ impl AnyLayer {
         if layer.is_null() {
             return Err(StyleError::Native(error_message));
         }
-        let layer_id = layers::layer_id(&layer);
-        let layer_type = layers::layer_type(&layer);
-
-        Ok(match layer_type.as_str() {
-            "circle" => {
-                Self::Circle(CircleLayer::from_ffi_parts(layer_id, layers::try_into_circle(layer)))
-            }
-            "fill" => Self::Fill(FillLayer::from_ffi_parts(layer_id, layers::try_into_fill(layer))),
-            "line" => Self::Line(LineLayer::from_ffi_parts(layer_id, layers::try_into_line(layer))),
-            "symbol" => {
-                Self::Symbol(SymbolLayer::from_ffi_parts(layer_id, layers::try_into_symbol(layer)))
-            }
-            _ => Self::Opaque(OpaqueLayer { layer_id, layer_type, layer }),
-        })
+        Self::from_layer_ptr(layer).ok_or(StyleError::Native(error_message))
     }
 
     /// Returns the layer's ID.

--- a/src/style/layers/circle.rs
+++ b/src/style/layers/circle.rs
@@ -20,7 +20,6 @@ impl CircleLayer {
         }
     }
 
-    #[cfg(feature = "json")]
     pub(crate) fn from_ffi_parts(layer_id: String, layer: UniquePtr<layers::CircleLayer>) -> Self {
         Self { layer_id, layer }
     }

--- a/src/style/layers/fill.rs
+++ b/src/style/layers/fill.rs
@@ -20,7 +20,6 @@ impl FillLayer {
         }
     }
 
-    #[cfg(feature = "json")]
     pub(crate) fn from_ffi_parts(layer_id: String, layer: UniquePtr<layers::FillLayer>) -> Self {
         Self { layer_id, layer }
     }

--- a/src/style/layers/line.rs
+++ b/src/style/layers/line.rs
@@ -78,7 +78,6 @@ impl LineLayer {
         }
     }
 
-    #[cfg(feature = "json")]
     pub(crate) fn from_ffi_parts(layer_id: String, layer: UniquePtr<layers::LineLayer>) -> Self {
         Self { layer_id, layer }
     }

--- a/src/style/layers/symbol.rs
+++ b/src/style/layers/symbol.rs
@@ -68,7 +68,6 @@ impl SymbolLayer {
         }
     }
 
-    #[cfg(feature = "json")]
     pub(crate) fn from_ffi_parts(layer_id: String, layer: UniquePtr<layers::SymbolLayer>) -> Self {
         Self { layer_id, layer }
     }

--- a/src/style/style_ref.rs
+++ b/src/style/style_ref.rs
@@ -1,7 +1,7 @@
 use image::DynamicImage;
 
 use crate::bridge::ffi;
-use crate::{ImageId, ImageRenderer, Layer, LayerId, Source, SourceId, StyleError};
+use crate::{AnyLayer, ImageId, ImageRenderer, Layer, LayerId, Source, SourceId, StyleError};
 
 /// A mutable reference to the renderer's current map style.
 #[derive(Debug)]
@@ -100,11 +100,13 @@ impl<'a, S> StyleRef<'a, S> {
         Ok(())
     }
 
-    /// Removes a layer from the current map style by ID.
+    /// Removes a layer from the current map style by ID and returns it.
     ///
-    /// No-op if `layer_id` does not match an existing layer.
-    pub fn remove_layer(&mut self, layer_id: impl AsRef<str>) {
-        self.image_renderer.instance.pin_mut().style_remove_layer(layer_id.as_ref());
+    /// Returns `None` if `layer_id` does not match an existing layer.
+    pub fn remove_layer(&mut self, layer_id: impl AsRef<str>) -> Option<AnyLayer> {
+        AnyLayer::from_layer_ptr(
+            self.image_renderer.instance.pin_mut().style_remove_layer(layer_id.as_ref()),
+        )
     }
 
     /// Removes a source from the current map style by ID.

--- a/tests/style_geojson_layers.rs
+++ b/tests/style_geojson_layers.rs
@@ -97,6 +97,14 @@ where
     }
 }
 
+fn center_pixel(image: &image::RgbaImage) -> image::Rgba<u8> {
+    *image.get_pixel(image.width() / 2, image.height() / 2)
+}
+
+fn render(renderer: &mut ImageRenderer<Static>) -> image::RgbaImage {
+    renderer.render_static(&camera(1.0)).expect("static render should succeed").as_image().clone()
+}
+
 #[test]
 fn geojson_source_renders_circle_line_and_fill_layers() {
     let mut renderer = renderer();
@@ -139,7 +147,7 @@ fn layer_management_methods_smoke_test() {
     let mut renderer = renderer();
     let mut style = renderer.style();
 
-    style.remove_layer("missing-layer");
+    assert!(style.remove_layer("missing-layer").is_none());
     style.remove_source("missing-source");
 
     let mut source = GeoJsonSource::new("removable-source");
@@ -172,9 +180,9 @@ fn layer_management_methods_smoke_test() {
         .expect("layer with missing before id should append");
     assert_eq!(missing_before_layer.as_str(), "missing-before-layer");
 
-    style.remove_layer(&before_layer);
-    style.remove_layer(&missing_before_layer);
-    style.remove_layer(&removable_layer);
+    assert!(style.remove_layer(&before_layer).is_some());
+    assert!(style.remove_layer(&missing_before_layer).is_some());
+    assert!(style.remove_layer(&removable_layer).is_some());
     style.remove_source(&source_id);
 
     let mut source = GeoJsonSource::new("removable-source");
@@ -190,4 +198,38 @@ fn layer_management_methods_smoke_test() {
     let image = render_until(&mut renderer, |image| has_non_background_pixel(image.as_image()));
     assert_eq!(image.as_image().width(), 128);
     assert_eq!(image.as_image().height(), 128);
+}
+
+#[test]
+fn removed_layer_can_be_added_again() {
+    let mut renderer = renderer();
+    let mut style = renderer.style();
+
+    let mut source = GeoJsonSource::new("move-source");
+    source.set_geojson(&overlay_geojson());
+    let source_id = style.add_source(source).expect("GeoJSON source should be added");
+
+    let mut red = CircleLayer::new("move-red", &source_id);
+    red.set_circle_color(Color::rgb(1.0, 0.0, 0.0));
+    red.set_circle_radius(24.0);
+    let red_layer = style.add_layer(red).expect("red layer should be added");
+
+    let mut green = CircleLayer::new("move-green", &source_id);
+    green.set_circle_color(Color::rgb(0.0, 1.0, 0.0));
+    green.set_circle_radius(24.0);
+    let green_layer =
+        style.add_layer_before(green, &red_layer).expect("green layer should be added below red");
+
+    let image = render(&mut renderer);
+    let [red, green, _blue, _alpha] = center_pixel(&image).0;
+    assert!(red > green, "red should render above green before removing");
+
+    let mut style = renderer.style();
+    let green = style.remove_layer(&green_layer).expect("green layer should be removed");
+    assert!(style.remove_layer("missing-layer").is_none());
+    style.add_layer(green).expect("green layer should be added again");
+
+    let image = render(&mut renderer);
+    let [red, green, _blue, _alpha] = center_pixel(&image).0;
+    assert!(green > red, "green should render above red after re-adding");
 }


### PR DESCRIPTION
MapLibre Native has no  `moveLayer`, so  `remove_layer` need to return the ownership of the layer if we want the equivalent.