### PR TITLE
feat(renderer): add camera_for_geojson and camera_for_lat_lngs

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -928,6 +928,13 @@ pub mod ffi {
         type Layer = super::layers::Layer;
     }
 
+    #[namespace = "mln::bridge::geojson"]
+    extern "C++" {
+        /// GeoJSON value opaque type.
+        #[rust_name = "FfiGeoJson"]
+        type GeoJson = super::geojson::GeoJson;
+    }
+
     // Declarations for Rust with implementations in C++
     unsafe extern "C++" {
         include!("map_renderer.h");
@@ -975,6 +982,22 @@ pub mod ffi {
         fn cameraForLatLngBounds(
             self: Pin<&mut MapRenderer>,
             bounds: &LatLngBounds,
+            padding: &EdgeInsets,
+            bearing: f64,
+            pitch: f64,
+        ) -> FfiCameraOptions;
+        /// Calculates camera options that fit geographic coordinates.
+        fn cameraForLatLngs(
+            self: Pin<&mut MapRenderer>,
+            lat_lngs: &[LatLng],
+            padding: &EdgeInsets,
+            bearing: f64,
+            pitch: f64,
+        ) -> FfiCameraOptions;
+        /// Calculates camera options that fit a GeoJSON value's geometry.
+        fn cameraForGeoJson(
+            self: Pin<&mut MapRenderer>,
+            geojson: &FfiGeoJson,
             padding: &EdgeInsets,
             bearing: f64,
             pitch: f64,

--- a/src/cpp/camera.cpp
+++ b/src/cpp/camera.cpp
@@ -1,8 +1,32 @@
 #include "maplibre_native/src/bridge.rs.h"
 
+#include "geojson/geojson.h"
+#include <mbgl/util/geojson.hpp>
+#include <mbgl/util/geometry.hpp>
+#include <mapbox/geojson.hpp>
+#include <vector>
+
 namespace mln {
 namespace bridge {
 namespace {
+
+// Reduces a GeoJSON value (geometry / feature / feature collection) to a single
+// geometry suitable for `Map::cameraForGeometry`.
+mbgl::Geometry<double> toGeometry(const mbgl::GeoJSON& geojson) {
+    return geojson.match(
+        [](const mapbox::geojson::geometry& geometry) -> mbgl::Geometry<double> { return geometry; },
+        [](const mapbox::geojson::feature& feature) -> mbgl::Geometry<double> {
+            return feature.geometry;
+        },
+        [](const mapbox::geojson::feature_collection& features) -> mbgl::Geometry<double> {
+            mapbox::geometry::geometry_collection<double> collection;
+            collection.reserve(features.size());
+            for (const auto& feature : features) {
+                collection.push_back(feature.geometry);
+            }
+            return collection;
+        });
+}
 
 mbgl::CameraOptions toCameraOptions(const FfiCameraOptions& camera) {
     mbgl::CameraOptions options;
@@ -78,6 +102,30 @@ FfiCameraOptions MapRenderer::cameraForLatLngBounds(const LatLngBounds& bounds,
     const mbgl::EdgeInsets mbglPadding{padding.top, padding.left, padding.bottom, padding.right};
 
     return fromCameraOptions(map->cameraForLatLngBounds(mbglBounds, mbglPadding, bearing, pitch));
+}
+
+FfiCameraOptions MapRenderer::cameraForLatLngs(rust::Slice<const LatLng> latLngs,
+                                               const EdgeInsets& padding,
+                                               double bearing,
+                                               double pitch) {
+    std::vector<mbgl::LatLng> mbglLatLngs;
+    mbglLatLngs.reserve(latLngs.size());
+    for (const auto& latLng : latLngs) {
+        mbglLatLngs.emplace_back(latLng.lat, latLng.lng);
+    }
+
+    const mbgl::EdgeInsets mbglPadding{padding.top, padding.left, padding.bottom, padding.right};
+    return fromCameraOptions(map->cameraForLatLngs(mbglLatLngs, mbglPadding, bearing, pitch));
+}
+
+FfiCameraOptions MapRenderer::cameraForGeoJson(const mln::bridge::geojson::GeoJson& geojson,
+                                               const EdgeInsets& padding,
+                                               double bearing,
+                                               double pitch) {
+    const mbgl::EdgeInsets mbglPadding{padding.top, padding.left, padding.bottom, padding.right};
+
+    return fromCameraOptions(
+        map->cameraForGeometry(toGeometry(geojson.get()), mbglPadding, bearing, pitch));
 }
 
 void MapRenderer::jumpTo(const FfiCameraOptions& cameraOptions) {

--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -41,8 +41,12 @@ constexpr size_t BYTES_PER_PIXEL = 4; // rgba
 struct BridgeImage;
 class RenderRequest;
 struct FfiCameraOptions;
+struct LatLng;
 struct LatLngBounds;
 struct EdgeInsets;
+namespace geojson {
+class GeoJson;
+}
 
 inline mbgl::util::RunLoop& threadRunLoop() {
     // MapLibre Native's RunLoop is thread-affine. Keep one private loop per
@@ -187,6 +191,16 @@ public:
                                            const EdgeInsets& padding,
                                            double bearing,
                                            double pitch);
+
+    FfiCameraOptions cameraForLatLngs(rust::Slice<const LatLng> latLngs,
+                                      const EdgeInsets& padding,
+                                      double bearing,
+                                      double pitch);
+
+    FfiCameraOptions cameraForGeoJson(const mln::bridge::geojson::GeoJson& geojson,
+                                      const EdgeInsets& padding,
+                                      double bearing,
+                                      double pitch);
 
     std::unique_ptr<std::string> readStillImageBytes() {
         return encodeImage(frontend->readStillImage());

--- a/src/renderer/image_renderer.rs
+++ b/src/renderer/image_renderer.rs
@@ -14,7 +14,8 @@ use crate::bridge::ffi::BridgeImage;
 use crate::renderer::map_observer::MapObserverCallbacks;
 use crate::renderer::{MapDebugOptions, MapLoadError, MapLoadErrorKind};
 use crate::{
-    CameraUpdate, EdgeInsets, LatLng, LatLngBounds, RunLoopHandle, ScreenCoordinate, Size, StyleRef,
+    CameraUpdate, EdgeInsets, GeoJson, LatLng, LatLngBounds, RunLoopHandle, ScreenCoordinate, Size,
+    StyleRef,
 };
 
 /// A rendered map image.
@@ -392,6 +393,46 @@ impl<S> ImageRenderer<S> {
         let camera =
             self.instance.pin_mut().cameraForLatLngBounds(&bounds, &padding, bearing, pitch);
         CameraUpdate::from_camera_options(camera)
+    }
+
+    /// Calculates a camera update that fits geographic coordinates.
+    ///
+    /// Returns `None` when `lat_lngs` is empty.
+    #[must_use]
+    pub fn camera_for_lat_lngs(
+        &mut self,
+        lat_lngs: &[LatLng],
+        padding: Option<EdgeInsets>,
+        bearing: f64,
+        pitch: f64,
+    ) -> Option<CameraUpdate> {
+        let padding = padding.unwrap_or_default();
+        let camera = self.instance.pin_mut().cameraForLatLngs(lat_lngs, &padding, bearing, pitch);
+        (camera.has_center || camera.has_zoom).then(|| CameraUpdate::from_camera_options(camera))
+    }
+
+    /// Calculates a camera update that fits a GeoJSON value's geometry.
+    ///
+    /// Accepts any GeoJSON (a geometry, feature, or feature collection); its
+    /// geometry is fit into the view.
+    ///
+    /// Returns `None` when there is no geometry to fit — e.g. an empty feature
+    /// collection or an empty geometry collection — in which case MapLibre
+    /// Native produces no camera.
+    #[must_use]
+    pub fn camera_for_geojson(
+        &mut self,
+        geojson: &GeoJson,
+        padding: Option<EdgeInsets>,
+        bearing: f64,
+        pitch: f64,
+    ) -> Option<CameraUpdate> {
+        let padding = padding.unwrap_or_default();
+        let camera =
+            self.instance.pin_mut().cameraForGeoJson(geojson.as_inner(), &padding, bearing, pitch);
+        // An empty geometry yields a default (empty) `CameraOptions`; report that
+        // as "could not fit" rather than a silent no-op camera.
+        (camera.has_center || camera.has_zoom).then(|| CameraUpdate::from_camera_options(camera))
     }
 
     fn submit_with_camera(

--- a/tests/image_renderer.rs
+++ b/tests/image_renderer.rs
@@ -8,8 +8,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use maplibre_native::{
-    CameraUpdate, EdgeInsets, ImageRenderer, ImageRendererBuilder, LatLng, LatLngBounds,
-    MapLoadErrorKind, RunLoopHandle, Static, Tile,
+    CameraUpdate, Color, EdgeInsets, FillLayer, GeoJson, GeoJsonSource, ImageRenderer,
+    ImageRendererBuilder, LatLng, LatLngBounds, MapLoadErrorKind, RunLoopHandle, Static, Tile,
 };
 
 const RENDER_TIMEOUT: Duration = Duration::from_secs(5);
@@ -176,6 +176,130 @@ fn camera_for_bounds_renders() {
     let image = request.finish().expect("bounds-fit renderer should render");
     assert_eq!(image.as_image().width(), 128);
     assert_eq!(image.as_image().height(), 128);
+}
+
+#[test]
+fn camera_for_lat_lngs_renders() {
+    let mut renderer = static_renderer();
+
+    renderer
+        .load_style_from_path(fixture_path("test-style.json"))
+        .expect("test style path should be valid");
+
+    let lat_lngs = [
+        LatLng { lat: -10.0, lng: -10.0 },
+        LatLng { lat: -10.0, lng: 10.0 },
+        LatLng { lat: 10.0, lng: 10.0 },
+        LatLng { lat: 10.0, lng: -10.0 },
+    ];
+    let camera = renderer
+        .camera_for_lat_lngs(&lat_lngs, Some(EdgeInsets::all(8.0)), 0.0, 0.0)
+        .expect("non-empty coordinates should produce a camera");
+    let request =
+        renderer.submit_render_static(&camera).expect("coordinates-fit render should submit");
+    tick_until_ready(|| request.is_ready());
+
+    let image = request.finish().expect("coordinates-fit renderer should render");
+    assert_eq!(image.as_image().width(), 128);
+    assert_eq!(image.as_image().height(), 128);
+}
+
+#[test]
+fn camera_for_lat_lngs_returns_none_for_empty_input() {
+    let mut renderer = static_renderer();
+    renderer
+        .load_style_from_path(fixture_path("test-style.json"))
+        .expect("test style path should be valid");
+
+    assert!(renderer.camera_for_lat_lngs(&[], None, 0.0, 0.0).is_none());
+}
+
+#[test]
+fn camera_for_geojson_renders() {
+    let mut renderer = static_renderer();
+
+    renderer
+        .load_style_from_path(fixture_path("test-style.json"))
+        .expect("test style path should be valid");
+
+    let geojson = r#"{
+        "type": "Polygon",
+        "coordinates": [[[-10.0, -10.0], [10.0, -10.0], [10.0, 10.0], [-10.0, 10.0], [-10.0, -10.0]]]
+    }"#
+    .parse::<GeoJson>()
+    .expect("inline GeoJSON should parse");
+
+    let camera = renderer
+        .camera_for_geojson(&geojson, Some(EdgeInsets::all(8.0)), 0.0, 0.0)
+        .expect("non-empty geometry should produce a camera");
+    let request =
+        renderer.submit_render_static(&camera).expect("geometry-fit render should submit");
+    tick_until_ready(|| request.is_ready());
+
+    let image = request.finish().expect("geometry-fit renderer should render");
+    assert_eq!(image.as_image().width(), 128);
+    assert_eq!(image.as_image().height(), 128);
+}
+
+#[test]
+fn camera_for_geojson_returns_none_for_empty_geometry() {
+    let mut renderer = static_renderer();
+    renderer
+        .load_style_from_path(fixture_path("test-style.json"))
+        .expect("test style path should be valid");
+
+    let empty = r#"{ "type": "FeatureCollection", "features": [] }"#
+        .parse::<GeoJson>()
+        .expect("inline GeoJSON should parse");
+
+    assert!(renderer.camera_for_geojson(&empty, None, 0.0, 0.0).is_none());
+}
+
+#[test]
+fn camera_for_geojson_matches_bounds() {
+    let mut renderer = static_renderer();
+    renderer
+        .load_style_from_path(fixture_path("test-style.json"))
+        .expect("test style path should be valid");
+
+    let polygon = r#"{
+        "type": "Polygon",
+        "coordinates": [[[-10.0, -10.0], [10.0, -10.0], [10.0, 10.0], [-10.0, 10.0], [-10.0, -10.0]]]
+    }"#
+    .parse::<GeoJson>()
+    .expect("inline GeoJSON should parse");
+
+    // Draw the polygon so the rendered output actually depends on the camera.
+    {
+        let mut style = renderer.style();
+        let mut source = GeoJsonSource::new("poly");
+        source.set_geojson(&polygon);
+        let source_id = style.add_source(source).expect("source should be added");
+        let mut fill = FillLayer::new("poly-fill", &source_id);
+        fill.set_fill_color(Color::rgb(1.0, 0.0, 0.0));
+        style.add_layer(fill).expect("fill layer should be added");
+    }
+
+    let render = |renderer: &mut ImageRenderer<Static>, camera: &CameraUpdate| {
+        let request = renderer.submit_render_static(camera).expect("render should submit");
+        tick_until_ready(|| request.is_ready());
+        request.finish().expect("render should succeed").as_image().clone()
+    };
+
+    let geo_camera = renderer
+        .camera_for_geojson(&polygon, Some(EdgeInsets::all(8.0)), 0.0, 0.0)
+        .expect("non-empty geometry should produce a camera");
+    let geo_image = render(&mut renderer, &geo_camera);
+
+    let bounds = LatLngBounds {
+        southwest: LatLng { lat: -10.0, lng: -10.0 },
+        northeast: LatLng { lat: 10.0, lng: 10.0 },
+    };
+    let bounds_camera = renderer.camera_for_bounds(bounds, Some(EdgeInsets::all(8.0)), 0.0, 0.0);
+    let bounds_image = render(&mut renderer, &bounds_camera);
+
+    // Fitting an axis-aligned rectangle by geometry must match fitting its bounds.
+    assert_eq!(geo_image, bounds_image);
 }
 
 #[test]


### PR DESCRIPTION
To support `auto` camera in static map image rendering, add `ImageRenderer::camera_for_geojson(&GeoJson, ...)`.

- Add `ImageRenderer::camera_for_geojson(&GeoJson, ...)` (wraps `Map::cameraForGeometry`)
- Also add `ImageRenderer::camera_for_lat_lngs(&[LatLng], ...)` (wraps `Map::cameraForLatLngs`).
