### PR TITLE
feat(style): support pixel ratio for style images

### DIFF
--- a/examples/slint/src/maplibre.rs
+++ b/examples/slint/src/maplibre.rs
@@ -106,7 +106,7 @@ fn style(map: &Rc<RefCell<MapLibre>>) {
     .unwrap()
     .decode()
     .unwrap();
-    let image_id = style.add_image("The id", &image, true).unwrap();
+    let image_id = style.add_image("The id", &image, 1.0, true).unwrap();
 
     let mut shapes_source = GeoJsonSource::new("shapes-source");
     let shapes = r#"{

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -1009,6 +1009,7 @@ pub mod ffi {
             id: &str,
             data: &[u8],
             size: Size,
+            pixel_ratio: f32,
             signed_distance_field: bool,
         ) -> Result<()>;
         /// Removes an image from the style.

--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -132,12 +132,12 @@ public:
     void style_add_image(rust::Str id,
                          rust::Slice<const unsigned char> data,
                          mbgl::Size size,
+                         float pixel_ratio,
                          bool signed_distance_field) {
         mbgl::PremultipliedImage image(size, data.data(), data.size());
 
-        const float pixelRatio = 1.0;
         map->getStyle().addImage(std::make_unique<mbgl::style::Image>(
-            std::string(id), std::move(image), pixelRatio, signed_distance_field));
+            std::string(id), std::move(image), pixel_ratio, signed_distance_field));
     }
 
     void style_remove_image(rust::Str id) {

--- a/src/style/style_ref.rs
+++ b/src/style/style_ref.rs
@@ -14,23 +14,6 @@ impl<'a, S> StyleRef<'a, S> {
         Self { image_renderer }
     }
 
-    /// Adds an image to the style with the given ID and options.
-    ///
-    /// Pass `true` for `signed_distance_field` to register the image as an SDF (signed
-    /// distance field) icon; pass `false` for a regular bitmap icon.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if MapLibre Native rejects the image.
-    pub fn add_image(
-        &mut self,
-        id: impl AsRef<str>,
-        image: &DynamicImage,
-        signed_distance_field: bool,
-    ) -> Result<ImageId, StyleError> {
-        self.add_image_with_pixel_ratio(id, image, 1.0, signed_distance_field)
-    }
-
     /// Adds an image to the style with the given ID, pixel ratio, and options.
     ///
     /// Pass `true` for `signed_distance_field` to register the image as an SDF (signed
@@ -39,7 +22,7 @@ impl<'a, S> StyleRef<'a, S> {
     /// # Errors
     ///
     /// Returns an error if MapLibre Native rejects the image.
-    pub fn add_image_with_pixel_ratio(
+    pub fn add_image(
         &mut self,
         id: impl AsRef<str>,
         image: &DynamicImage,

--- a/src/style/style_ref.rs
+++ b/src/style/style_ref.rs
@@ -28,6 +28,24 @@ impl<'a, S> StyleRef<'a, S> {
         image: &DynamicImage,
         signed_distance_field: bool,
     ) -> Result<ImageId, StyleError> {
+        self.add_image_with_pixel_ratio(id, image, 1.0, signed_distance_field)
+    }
+
+    /// Adds an image to the style with the given ID, pixel ratio, and options.
+    ///
+    /// Pass `true` for `signed_distance_field` to register the image as an SDF (signed
+    /// distance field) icon; pass `false` for a regular bitmap icon.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if MapLibre Native rejects the image.
+    pub fn add_image_with_pixel_ratio(
+        &mut self,
+        id: impl AsRef<str>,
+        image: &DynamicImage,
+        pixel_ratio: f32,
+        signed_distance_field: bool,
+    ) -> Result<ImageId, StyleError> {
         use image::EncodableLayout;
         let id = id.as_ref();
         let image = image.to_rgba8();
@@ -35,6 +53,7 @@ impl<'a, S> StyleRef<'a, S> {
             id,
             image.as_bytes(),
             ffi::Size { width: image.width(), height: image.height() },
+            pixel_ratio,
             signed_distance_field,
         )?;
         Ok(ImageId::new(id.to_owned()))


### PR DESCRIPTION
Adds `add_image_with_pixel_ratio` so high-DPI style images can be registered with the correct pixel ratio.