### PR TITLE
feat(build): use ninja generator on linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -393,10 +393,9 @@ fn build_local(
     // mandatory on Apple platforms. On Linux Ninja is optional, but it parallelises
     // better than Make; use it when it is installed and the user has not pinned a
     // generator via CMAKE_GENERATOR. Fall back to the default (Make) otherwise.
-    if target_os == "macos" || target_os == "ios" {
-        config.generator("Ninja");
-    } else if target_os == "linux" && env::var_os("CMAKE_GENERATOR").is_none() && ninja_available()
-    {
+    let is_ios = target_os == "macos" || target_os == "ios";
+    let linux_with_ninja = target_os == "linux" && env::var_os("CMAKE_GENERATOR").is_none() && ninja_available();
+    if is_ios || linux_with_ninja {
         config.generator("Ninja");
     }
 

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,8 @@
 //!
 //! IMPORTANT: The library path must point to the amalgan library which contains all the dependent libraries if `MLN_CORE_LIBRARY_NO_AMALGAM` is not set!
 //!
+//! On Linux the Ninja generator is used automatically when `ninja` is on `PATH` (unless `CMAKE_GENERATOR` is set), falling back to Make.
+//!
 //! Required libraries:
 //! Fedora:
 //!     - `sudo dnf install libicu-devel libglslang-devel spirv-tools-devel libpng-devel libjpeg-turbo-devel libuv-devel libwebp-devel`
@@ -47,6 +49,11 @@ const BRIDGE_FILES: &[&str] = &[
 ];
 
 const BRIDGE_INCLUDE_DIRS: &[&str] = &["include", "src/cpp"];
+
+/// Returns `true` if a `ninja` executable is available on `PATH`.
+fn ninja_available() -> bool {
+    Command::new("ninja").arg("--version").output().is_ok_and(|out| out.status.success())
+}
 
 /// Supported graphics rendering APIs.
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -382,8 +389,16 @@ fn build_local(
     config.build_target(TARGET_NAME);
 
     // maplibre-native's platform/darwin/darwin.cmake calls enable_language(Swift),
-    // which the default "Unix Makefiles" generator does not support. Switch to Ninja.
+    // which the default "Unix Makefiles" generator does not support, so Ninja is
+    // mandatory on Apple platforms. On Linux Ninja is optional, but it parallelises
+    // better than Make; use it when it is installed and the user has not pinned a
+    // generator via CMAKE_GENERATOR. Fall back to the default (Make) otherwise.
     if target_os == "macos" || target_os == "ios" {
+        config.generator("Ninja");
+    } else if target_os == "linux"
+        && env::var_os("CMAKE_GENERATOR").is_none()
+        && ninja_available()
+    {
         config.generator("Ninja");
     }
 

--- a/build.rs
+++ b/build.rs
@@ -394,7 +394,8 @@ fn build_local(
     // better than Make; use it when it is installed and the user has not pinned a
     // generator via CMAKE_GENERATOR. Fall back to the default (Make) otherwise.
     let is_ios = target_os == "macos" || target_os == "ios";
-    let linux_with_ninja = target_os == "linux" && env::var_os("CMAKE_GENERATOR").is_none() && ninja_available();
+    let linux_with_ninja =
+        target_os == "linux" && env::var_os("CMAKE_GENERATOR").is_none() && ninja_available();
     if is_ios || linux_with_ninja {
         config.generator("Ninja");
     }

--- a/build.rs
+++ b/build.rs
@@ -395,9 +395,7 @@ fn build_local(
     // generator via CMAKE_GENERATOR. Fall back to the default (Make) otherwise.
     if target_os == "macos" || target_os == "ios" {
         config.generator("Ninja");
-    } else if target_os == "linux"
-        && env::var_os("CMAKE_GENERATOR").is_none()
-        && ninja_available()
+    } else if target_os == "linux" && env::var_os("CMAKE_GENERATOR").is_none() && ninja_available()
     {
         config.generator("Ninja");
     }


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
- [x] Briefly describe the changes in this PR.

I THINK this is faster, but we will see this.
By default, we are using make which is not known for being the fastest kid on the block

So as a "rough, unscientific proof":
- this PR -> https://github.com/maplibre/maplibre-native-rs/actions/runs/27038231435/job/79807535840?pr=223
- previous PR -> https://github.com/maplibre/maplibre-native-rs/actions/runs/26923224376/job/79427884202