### PR TITLE
fix: seed slint example map with preferred size

### DIFF
--- a/examples/slint/src/main.rs
+++ b/examples/slint/src/main.rs
@@ -5,8 +5,10 @@ slint::include_modules!();
 fn main() {
     let ui = MainWindow::new().unwrap();
 
-    let size = ui.get_map_size();
-    let map = maplibre::create_map(size);
+    // The window has no size until `ui.run()` lays it out, so seed the map with the preferred size.
+    // `on_map_size_changed` (in `init`) resizes it once shown.
+    let (width, height) = maplibre::DEFAULT_MAP_SIZE;
+    let map = maplibre::create_map(width, height);
 
     maplibre::init(&ui, &map);
 

--- a/examples/slint/src/maplibre.rs
+++ b/examples/slint/src/maplibre.rs
@@ -8,7 +8,7 @@ use slint::ComponentHandle;
 use std::rc::Rc;
 mod headless;
 pub use headless::MapLibre;
-pub use headless::create_map;
+pub use headless::{DEFAULT_MAP_SIZE, create_map};
 use image::ImageReader;
 use maplibre_native::Style;
 use maplibre_native::{GeoJsonSource, Latitude, Longitude, SymbolLayer};

--- a/examples/slint/src/maplibre/headless.rs
+++ b/examples/slint/src/maplibre/headless.rs
@@ -1,4 +1,3 @@
-use crate::Size;
 use maplibre_native::Continuous;
 use maplibre_native::ImageRenderer;
 use maplibre_native::ImageRendererBuilder;
@@ -58,17 +57,19 @@ impl MapLibre {
     }
 }
 
-pub fn create_map(size: Size) -> Rc<RefCell<MapLibre>> {
+/// Initial renderer size, matching the window's preferred size.
+/// The real size is applied later via `on_map_size_changed`.
+pub const DEFAULT_MAP_SIZE: (NonZeroU32, NonZeroU32) =
+    (NonZeroU32::new(800).unwrap(), NonZeroU32::new(600).unwrap());
+
+pub fn create_map(width: NonZeroU32, height: NonZeroU32) -> Rc<RefCell<MapLibre>> {
     let resource_options = ResourceOptions::default()
         .with_tile_server_options(&TileServerOptions::default())
         // .with_api_key(api_key)
         .with_cache_path(Path::new(env!("CARGO_MANIFEST_DIR")).join("maplibre_database.sqlite"));
 
     let mut renderer = ImageRendererBuilder::new()
-        .with_size(
-            NonZeroU32::new(size.width as u32).unwrap(),
-            NonZeroU32::new(size.height as u32).unwrap(),
-        )
+        .with_size(width, height)
         .with_pixel_ratio(1.0)
         .with_resource_options(resource_options)
         .build_continuous_renderer();


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!

I am running into a bit of a race condition (?) with this example.
Because the window does not exist, I get this error.

```
     Running `/home/frank/dev/maplibre/maplibre-native-rs/target/debug/slint_map_libre_native`
MainWindow width:  0(px) , Height:  0(px)

thread 'main' (3095076) panicked at examples/slint/src/maplibre/headless.rs:69:48:
called `Option::unwrap()` on a `None` value
stack backtrace:
[..]
/library/core/src/option.rs:2236:5
   4: core::option::Option<T>::unwrap
             at /home/frank/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:1016:21
   5: slint_map_libre_native::maplibre::headless::create_map
             at ./src/maplibre/headless.rs:69:48
   6: slint_map_libre_native::main
             at ./src/main.rs:9:15
   7: core::ops::function::FnOnce::call_once
             at /home/frank/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
```

So my solution to this would be that the example needs to init at some size, then can resize to whatever slint is resized to 😉 

I am not an slint expert, feel free to overrule if this is a dumb idea or there is a better way.