### PR TITLE
build: don't configure glfw demo app (and its opengl-only x11 dependency)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  # Otherwise egl initialisation fails
-  # In CI we don't have a display-surface to render to
-  EGL_PLATFORM: surfaceless
 jobs:
   lint:
     name: Lint

--- a/build.rs
+++ b/build.rs
@@ -391,10 +391,8 @@ fn build_local(
         config.configure_arg("-DMLN_WITH_X11=ON");
     }
 
-    // We only build the `mbgl-core` target, so don't let cmake configure the GLFW
-    // demo app (and pull in its glfw3 dependency). NOTE: at the pinned MLN_COMMIT
-    // the offline/render-test/benchmark tools are added unconditionally with no
-    // opt-out flag, so GLFW is the only extra target gateable here.
+    // We only build the `mbgl-core` target
+    // This menas we don't let cmake configure the GLFW demo app (and pull in its glfw3 dependency).
     config.configure_arg("-DMLN_WITH_GLFW=OFF");
 
     let dest = config.build();

--- a/build.rs
+++ b/build.rs
@@ -390,6 +390,13 @@ fn build_local(
         config.configure_arg("-DMLN_WITH_WAYLAND=OFF");
         config.configure_arg("-DMLN_WITH_X11=ON");
     }
+
+    // We only build the `mbgl-core` target, so don't let cmake configure the GLFW
+    // demo app (and pull in its glfw3 dependency). NOTE: at the pinned MLN_COMMIT
+    // the offline/render-test/benchmark tools are added unconditionally with no
+    // opt-out flag, so GLFW is the only extra target gateable here.
+    config.configure_arg("-DMLN_WITH_GLFW=OFF");
+
     let dest = config.build();
     println!("cargo:rustc-link-search=native={}", dest.join("build").display());
     println!(

--- a/build.rs
+++ b/build.rs
@@ -392,7 +392,7 @@ fn build_local(
     }
 
     // We only build the `mbgl-core` target
-    // This menas we don't let cmake configure the GLFW demo app (and pull in its glfw3 dependency).
+    // This means we don't let cmake configure the GLFW demo app (and pull in its glfw3 dependency).
     config.configure_arg("-DMLN_WITH_GLFW=OFF");
 
     let dest = config.build();

--- a/build.rs
+++ b/build.rs
@@ -378,23 +378,25 @@ fn build_local(
         }
         GraphicsRenderingAPI::OpenGL => {
             config.configure_arg("-DMLN_WITH_OPENGL=ON");
+            #[cfg(target_os = "linux")]
+            // GLX headless backend transitively requires X11.
+            config.configure_arg("-DMLN_WITH_X11=ON");
         }
         GraphicsRenderingAPI::Vulkan => {
             config.configure_arg("-DMLN_WITH_VULKAN=ON");
+            #[cfg(target_os = "linux")]
+            // Vulkan has no X11 dependency.
+            config.configure_arg("-DMLN_WITH_X11=OFF");
         } //GraphicsRenderingAPI::WebGPU => config.configure_arg("-DMLN_WITH_WEBGPU=ON").configure_arg("-DMLN_WEBGPU_IMPL_WGPU=ON"),
     }
     if amalgam_lib {
         config.configure_arg("-DMLN_CREATE_AMALGAMATION:BOOL=ON");
     }
-    if cfg!(target_os = "linux") {
-        config.configure_arg("-DMLN_WITH_WAYLAND=OFF");
-        config.configure_arg("-DMLN_WITH_X11=ON");
-    }
+    #[cfg(target_os = "linux")]
+    config.configure_arg("-DMLN_WITH_WAYLAND=OFF");
 
-    // We only build the `mbgl-core` target
-    // This means we don't let cmake configure the GLFW demo app (and pull in its glfw3 and its x11 dependency).
+    // We only build the `mbgl-core` target, so skip configuring the GLFW demo app.
     config.configure_arg("-DMLN_WITH_GLFW=OFF");
-    config.configure_arg("-DMLN_WITH_X11=OFF");
 
     let dest = config.build();
     println!("cargo:rustc-link-search=native={}", dest.join("build").display());
@@ -549,7 +551,6 @@ fn build_mln() {
         GraphicsRenderingAPI::Vulkan => {}
         GraphicsRenderingAPI::OpenGL => {
             println!("cargo:rustc-link-lib=GL");
-            println!("cargo:rustc-link-lib=EGL");
             if cfg!(target_os = "linux") {
                 // GLX backend uses X11 symbols such as XInitThreads.
                 println!("cargo:rustc-link-lib=X11");

--- a/build.rs
+++ b/build.rs
@@ -392,8 +392,9 @@ fn build_local(
     }
 
     // We only build the `mbgl-core` target
-    // This means we don't let cmake configure the GLFW demo app (and pull in its glfw3 dependency).
+    // This means we don't let cmake configure the GLFW demo app (and pull in its glfw3 and its x11 dependency).
     config.configure_arg("-DMLN_WITH_GLFW=OFF");
+    config.configure_arg("-DMLN_WITH_X11=OFF");
 
     let dest = config.build();
     println!("cargo:rustc-link-search=native={}", dest.join("build").display());

--- a/build.rs
+++ b/build.rs
@@ -399,8 +399,8 @@ fn build_local(
 
     // We only build the `mbgl-core` target, so skip configuring the GLFW demo app.
     config.configure_arg("-DMLN_WITH_GLFW=OFF");
-  
-      // Forward an optional compiler launcher (sccache/ccache) so downstream CI can
+
+    // Forward an optional compiler launcher (sccache/ccache) so downstream CI can
     // cache the C++ objects without patching this crate.
     println!("cargo:rerun-if-env-changed=MLN_CMAKE_CXX_LAUNCHER");
     if let Ok(launcher) = env::var("MLN_CMAKE_CXX_LAUNCHER") {

--- a/justfile
+++ b/justfile
@@ -90,7 +90,7 @@ get-msrv package=main_crate:  (get-crate-field 'rust_version' package)
 install-dependencies backend='vulkan':
     sudo apt-get update
     sudo apt-get install -y \
-      {{if backend == 'opengl' {'libgl1-mesa-dev libglu1-mesa-dev'} else if backend == 'vulkan' {'mesa-vulkan-drivers glslang-dev'} else {''} }} \
+      {{if backend == 'opengl' {'libgl1-mesa-dev libglu1-mesa-dev libx11-dev xvfb'} else if backend == 'vulkan' {'mesa-vulkan-drivers glslang-dev'} else {''} }} \
       build-essential \
       libcurl4-openssl-dev \
       libuv1-dev \
@@ -104,7 +104,6 @@ install-dependencies backend='vulkan':
       libwebp-dev \
       ccache \
       cmake \
-      xvfb \
       pkg-config # required for fontconfig detection
 
 # Install macOS dependencies via Homebrew.

--- a/justfile
+++ b/justfile
@@ -93,7 +93,6 @@ install-dependencies backend='vulkan':
       {{if backend == 'opengl' {'libgl1-mesa-dev libglu1-mesa-dev'} else if backend == 'vulkan' {'mesa-vulkan-drivers glslang-dev'} else {''} }} \
       build-essential \
       libcurl4-openssl-dev \
-      libx11-dev \
       libuv1-dev \
       libz-dev \
       libfontconfig-dev \

--- a/justfile
+++ b/justfile
@@ -90,10 +90,10 @@ get-msrv package=main_crate:  (get-crate-field 'rust_version' package)
 install-dependencies backend='vulkan':
     sudo apt-get update
     sudo apt-get install -y \
-      {{if backend == 'opengl' {'libgl1-mesa-dev libglu1-mesa-dev libx11-dev'} else if backend == 'vulkan' {'mesa-vulkan-drivers glslang-dev'} else {''} }} \
+      {{if backend == 'opengl' {'libgl1-mesa-dev libglu1-mesa-dev'} else if backend == 'vulkan' {'mesa-vulkan-drivers glslang-dev'} else {''} }} \
       build-essential \
       libcurl4-openssl-dev \
-      libglfw3-dev \
+      libx11-dev \
       libuv1-dev \
       libz-dev \
       libfontconfig-dev \
@@ -117,7 +117,6 @@ install-dependencies backend='vulkan':
         cmake \
         ninja \
         curl \
-        glfw \
         libuv \
         libpng \
         jpeg-turbo \


### PR DESCRIPTION
Is default enabled, but unused. slint and the other demos work as expected.

@louwers is this intentional that this is in the default set?