### PR TITLE
feat(style): add JSON source conversion

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -380,9 +380,12 @@ pub mod style_value {
     #[namespace = "mbgl::style"]
     extern "C++" {
         include!("mbgl/style/layer.hpp");
+        include!("mbgl/style/source.hpp");
 
         #[rust_name = "StyleLayer"]
         type Layer = crate::bridge::layers::Layer;
+        #[rust_name = "StyleSource"]
+        type Source = crate::bridge::sources::Source;
     }
 
     unsafe extern "C++" {
@@ -420,6 +423,14 @@ pub mod style_value {
             value: &StyleValue,
             error_message: &mut String,
         ) -> UniquePtr<StyleLayer>;
+
+        /// Parses a style-spec source object from a `StyleValue` tree.
+        /// On failure, `error_message` is populated and the returned pointer is null.
+        fn source_from_value(
+            id: &str,
+            value: &StyleValue,
+            error_message: &mut String,
+        ) -> UniquePtr<StyleSource>;
     }
 }
 

--- a/src/cpp/style_value.cpp
+++ b/src/cpp/style_value.cpp
@@ -13,12 +13,43 @@
 namespace mln::bridge {
 namespace {
 
-// Converts a `StyleValue` tree back to JSON text
-std::string stringify_style_value(const StyleValue& value) {
-    std::ostringstream json;
-    json.imbue(std::locale::classic());
-    append_json(json, value);
-    return json.str();
+// Escapes and quotes a string as a JSON string literal.
+void append_json_string(std::ostringstream& out, const std::string& value) {
+    out << '"';
+    for (unsigned char c : value) {
+        switch (c) {
+        case '"':
+            out << "\\\"";
+            break;
+        case '\\':
+            out << "\\\\";
+            break;
+        case '\b':
+            out << "\\b";
+            break;
+        case '\f':
+            out << "\\f";
+            break;
+        case '\n':
+            out << "\\n";
+            break;
+        case '\r':
+            out << "\\r";
+            break;
+        case '\t':
+            out << "\\t";
+            break;
+        default:
+            if (c < 0x20) {
+                out << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(c)
+                    << std::dec << std::setfill(' ');
+            } else {
+                out << static_cast<char>(c);
+            }
+            break;
+        }
+    }
+    out << '"';
 }
 
 void append_json(std::ostringstream& out, const StyleValue& value) {
@@ -66,42 +97,13 @@ void append_json(std::ostringstream& out, const StyleValue& value) {
     }
 }
 
-void append_json_string(std::ostringstream& out, const std::string& value) {
-    out << '"';
-    for (unsigned char c : value) {
-        switch (c) {
-        case '"':
-            out << "\\\"";
-            break;
-        case '\\':
-            out << "\\\\";
-            break;
-        case '\b':
-            out << "\\b";
-            break;
-        case '\f':
-            out << "\\f";
-            break;
-        case '\n':
-            out << "\\n";
-            break;
-        case '\r':
-            out << "\\r";
-            break;
-        case '\t':
-            out << "\\t";
-            break;
-        default:
-            if (c < 0x20) {
-                out << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(c)
-                    << std::dec << std::setfill(' ');
-            } else {
-                out << static_cast<char>(c);
-            }
-            break;
-        }
-    }
-    out << '"';
+// Converts a `StyleValue` tree back to JSON text
+std::string stringify_style_value(const StyleValue& value) {
+    std::ostringstream json;
+    // Force a locale-independent decimal point ('.') so numbers stay valid JSON.
+    json.imbue(std::locale::classic());
+    append_json(json, value);
+    return json.str();
 }
 
 } // namespace

--- a/src/cpp/style_value.cpp
+++ b/src/cpp/style_value.cpp
@@ -13,6 +13,11 @@
 namespace mln::bridge {
 namespace {
 
+// Stringify a `StyleValue` tree to JSON, for `toGeoJSON()` on inline GeoJSON
+// (source `data`, `["within"]` / `["distance"]` expressions).
+//
+// Note: open to a cleaner approach than this JSON round-trip in C++.
+
 // Escapes and quotes a string as a JSON string literal.
 void append_json_string(std::ostringstream& out, const std::string& value) {
     out << '"';
@@ -97,7 +102,6 @@ void append_json(std::ostringstream& out, const StyleValue& value) {
     }
 }
 
-// Converts a `StyleValue` tree back to JSON text
 std::string stringify_style_value(const StyleValue& value) {
     std::ostringstream json;
     // Force a locale-independent decimal point ('.') so numbers stay valid JSON.
@@ -166,8 +170,6 @@ std::unique_ptr<mbgl::style::Source> source_from_value(rust::Str id,
 
 std::optional<mbgl::GeoJSON> style_value_to_geojson(const StyleValue& value,
                                                     mbgl::style::conversion::Error& error) {
-    // Note: This goes through JSON text to keep the adapter small; it can be
-    // optimized later if source conversion becomes a hot path.
     try {
         return mapbox::geojson::parse(stringify_style_value(value));
     } catch (const std::exception& ex) {

--- a/src/cpp/style_value.cpp
+++ b/src/cpp/style_value.cpp
@@ -1,11 +1,110 @@
 #include "style_value.h"
 
 #include <mbgl/style/conversion/layer.hpp>
+#include <mbgl/style/conversion/source.hpp>
+#include <mapbox/geojson.hpp>
 
+#include <iomanip>
+#include <locale>
+#include <sstream>
 #include <string>
 #include <utility>
 
 namespace mln::bridge {
+namespace {
+
+// Converts a `StyleValue` tree back to JSON text
+std::string stringify_style_value(const StyleValue& value) {
+    std::ostringstream json;
+    json.imbue(std::locale::classic());
+    append_json(json, value);
+    return json.str();
+}
+
+void append_json(std::ostringstream& out, const StyleValue& value) {
+    switch (value.kind()) {
+    case StyleValue::Kind::Null:
+        out << "null";
+        break;
+    case StyleValue::Kind::Bool:
+        out << (value.boolean() ? "true" : "false");
+        break;
+    case StyleValue::Kind::Number:
+        out << std::setprecision(17) << value.number();
+        break;
+    case StyleValue::Kind::String:
+        append_json_string(out, value.str());
+        break;
+    case StyleValue::Kind::Array: {
+        out << '[';
+        bool first = true;
+        for (const auto& child : value.array()) {
+            if (!first) {
+                out << ',';
+            }
+            first = false;
+            append_json(out, *child);
+        }
+        out << ']';
+        break;
+    }
+    case StyleValue::Kind::Object: {
+        out << '{';
+        bool first = true;
+        for (const auto& entry : value.object()) {
+            if (!first) {
+                out << ',';
+            }
+            first = false;
+            append_json_string(out, entry.first);
+            out << ':';
+            append_json(out, *entry.second);
+        }
+        out << '}';
+        break;
+    }
+    }
+}
+
+void append_json_string(std::ostringstream& out, const std::string& value) {
+    out << '"';
+    for (unsigned char c : value) {
+        switch (c) {
+        case '"':
+            out << "\\\"";
+            break;
+        case '\\':
+            out << "\\\\";
+            break;
+        case '\b':
+            out << "\\b";
+            break;
+        case '\f':
+            out << "\\f";
+            break;
+        case '\n':
+            out << "\\n";
+            break;
+        case '\r':
+            out << "\\r";
+            break;
+        case '\t':
+            out << "\\t";
+            break;
+        default:
+            if (c < 0x20) {
+                out << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(c)
+                    << std::dec << std::setfill(' ');
+            } else {
+                out << static_cast<char>(c);
+            }
+            break;
+        }
+    }
+    out << '"';
+}
+
+} // namespace
 
 std::unique_ptr<StyleValue> make_null() {
     return std::make_unique<StyleValue>();
@@ -48,6 +147,34 @@ std::unique_ptr<mbgl::style::Layer> layer_from_value(const StyleValue& value, ru
         return nullptr;
     }
     return std::move(*result);
+}
+
+std::unique_ptr<mbgl::style::Source> source_from_value(rust::Str id,
+                                                       const StyleValue& value,
+                                                       rust::String& error_message) {
+    mbgl::style::conversion::Error error;
+    auto result = mbgl::style::conversion::Converter<std::unique_ptr<mbgl::style::Source>>()(
+        mbgl::style::conversion::Convertible(&value), error, std::string(id));
+    if (!result) {
+        error_message = rust::String(error.message);
+        return nullptr;
+    }
+    return std::move(*result);
+}
+
+std::optional<mbgl::GeoJSON> style_value_to_geojson(const StyleValue& value,
+                                                    mbgl::style::conversion::Error& error) {
+    // Note: This goes through JSON text to keep the adapter small; it can be
+    // optimized later if source conversion becomes a hot path.
+    try {
+        return mapbox::geojson::parse(stringify_style_value(value));
+    } catch (const std::exception& ex) {
+        error.message = ex.what();
+        return std::nullopt;
+    } catch (...) {
+        error.message = "failed to parse GeoJSON";
+        return std::nullopt;
+    }
 }
 
 } // namespace mln::bridge

--- a/src/cpp/style_value.h
+++ b/src/cpp/style_value.h
@@ -190,6 +190,8 @@ public:
     return {};
   }
 
+  // A GeoJSON source's `data` may be an inline GeoJSON object (not only a URL
+  // string), so source conversion calls this to parse it from the StyleValue tree.
   static std::optional<GeoJSON> toGeoJSON(T value, Error &error) {
     if (value == nullptr) {
       error = {"GeoJSON value must not be null"};

--- a/src/cpp/style_value.h
+++ b/src/cpp/style_value.h
@@ -3,6 +3,8 @@
 #include <mbgl/style/conversion.hpp>
 #include <mbgl/style/conversion_impl.hpp>
 #include <mbgl/style/layer.hpp>
+#include <mbgl/style/source.hpp>
+#include <mbgl/util/geojson.hpp>
 
 #include <cmath>
 #include <cstdint>
@@ -76,6 +78,15 @@ void object_insert(StyleValue &obj, rust::Str key,
 // Parses a style-spec `Layer` object.
 std::unique_ptr<mbgl::style::Layer>
 layer_from_value(const StyleValue &value, rust::String &error_message);
+
+// Parses a style-spec `Source` object.
+std::unique_ptr<mbgl::style::Source>
+source_from_value(rust::Str id, const StyleValue &value,
+                  rust::String &error_message);
+
+std::optional<mbgl::GeoJSON>
+style_value_to_geojson(const StyleValue &value,
+                       mbgl::style::conversion::Error &error);
 
 } // namespace mln::bridge
 
@@ -179,9 +190,12 @@ public:
     return {};
   }
 
-  static std::optional<GeoJSON> toGeoJSON(T, Error &error) {
-    error = {"GeoJSON conversion from StyleValue is not implemented"};
-    return {};
+  static std::optional<GeoJSON> toGeoJSON(T value, Error &error) {
+    if (value == nullptr) {
+      error = {"GeoJSON value must not be null"};
+      return {};
+    }
+    return mln::bridge::style_value_to_geojson(*value, error);
   }
 };
 

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -19,7 +19,7 @@ pub use layers::{
     SymbolAnchor, SymbolLayer,
 };
 pub use sources::{
-    GeoJsonSource, GeoJsonSourceRefMut, OpaqueSourceRefMut, Source, SourceId, SourceRefMut,
-    SourceType,
+    AnySource, GeoJsonSource, GeoJsonSourceRefMut, OpaqueSource, OpaqueSourceRefMut, Source,
+    SourceId, SourceRefMut, SourceType,
 };
 pub use style_ref::StyleRef;

--- a/src/style/sources/any.rs
+++ b/src/style/sources/any.rs
@@ -1,0 +1,108 @@
+use std::fmt;
+
+use cxx::UniquePtr;
+
+use crate::bridge::ffi;
+#[cfg(feature = "json")]
+use crate::bridge::style_value;
+#[cfg(feature = "json")]
+use crate::style::{value::build_style_value, StyleError};
+
+/// A style source of a type that does not (yet) have a typed Rust wrapper.
+pub struct OpaqueSource {
+    source_id: String,
+    source: UniquePtr<ffi::CxxSource>,
+}
+
+impl OpaqueSource {
+    /// Returns the source's ID.
+    #[must_use]
+    pub fn source_id(&self) -> &str {
+        &self.source_id
+    }
+
+    pub(crate) fn into_inner(self) -> UniquePtr<ffi::CxxSource> {
+        self.source
+    }
+}
+
+impl fmt::Debug for OpaqueSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpaqueSource").field("source_id", &self.source_id).finish_non_exhaustive()
+    }
+}
+
+/// A style source of any type, parsed from a style-spec source object.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum AnySource {
+    /// A source of a type that does not have a typed wrapper in this crate yet.
+    Opaque(OpaqueSource),
+}
+
+impl AnySource {
+    // Currently only reachable from the JSON parsing path; gate it so non-`json`
+    // builds don't see it as dead code.
+    #[cfg(feature = "json")]
+    pub(crate) fn from_source_ptr(
+        source_id: String,
+        source: UniquePtr<ffi::CxxSource>,
+    ) -> Option<Self> {
+        if source.is_null() {
+            return None;
+        }
+
+        Some(Self::Opaque(OpaqueSource { source_id, source }))
+    }
+
+    /// Parses a single style-spec source object from a JSON string.
+    ///
+    /// Source objects do not contain their ID, so `id` is provided separately.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StyleError::Json`] if the input is not valid JSON, or
+    /// [`StyleError::Native`] if MapLibre Native rejects the source.
+    #[cfg(feature = "json")]
+    pub fn from_json_str(id: impl AsRef<str>, json: &str) -> Result<Self, StyleError> {
+        let value: serde_json::Value = serde_json::from_str(json)?;
+        Self::from_json_value(id, &value)
+    }
+
+    /// Parses a style-spec source object from a [`serde_json::Value`].
+    ///
+    /// Source objects do not contain their ID, so `id` is provided separately.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StyleError::JsonNumber`] if a JSON number cannot be converted,
+    /// or [`StyleError::Native`] if MapLibre Native rejects the value.
+    #[cfg(feature = "json")]
+    pub fn from_json_value(
+        id: impl AsRef<str>,
+        value: &serde_json::Value,
+    ) -> Result<Self, StyleError> {
+        let id = id.as_ref();
+        let style_value = build_style_value(value)?;
+        let mut error_message = String::new();
+        let source = style_value::source_from_value(id, &style_value, &mut error_message);
+        if source.is_null() {
+            return Err(StyleError::Native(error_message));
+        }
+        Self::from_source_ptr(id.to_owned(), source).ok_or(StyleError::Native(error_message))
+    }
+
+    /// Returns the source's ID.
+    #[must_use]
+    pub fn source_id(&self) -> &str {
+        match self {
+            Self::Opaque(s) => s.source_id(),
+        }
+    }
+
+    pub(crate) fn into_inner(self) -> UniquePtr<ffi::CxxSource> {
+        match self {
+            Self::Opaque(s) => s.into_inner(),
+        }
+    }
+}

--- a/src/style/sources/mod.rs
+++ b/src/style/sources/mod.rs
@@ -1,8 +1,10 @@
+mod any;
 mod geojson;
 mod id;
 mod refs;
 mod traits;
 
+pub use any::{AnySource, OpaqueSource};
 pub use geojson::{GeoJsonSource, GeoJsonSourceRefMut};
 pub use id::SourceId;
 pub use refs::{OpaqueSourceRefMut, SourceRefMut, SourceType};

--- a/src/style/sources/traits.rs
+++ b/src/style/sources/traits.rs
@@ -1,7 +1,7 @@
 use sealed::IntoSource;
 
 use crate::bridge::{ffi, sources};
-use crate::style::GeoJsonSource;
+use crate::style::{AnySource, GeoJsonSource};
 
 mod sealed {
     use crate::bridge::ffi;
@@ -29,3 +29,15 @@ impl IntoSource for GeoJsonSource {
 }
 
 impl Source for GeoJsonSource {}
+
+impl IntoSource for AnySource {
+    fn source_id(&self) -> &str {
+        self.source_id()
+    }
+
+    fn into_source(self) -> cxx::UniquePtr<ffi::CxxSource> {
+        self.into_inner()
+    }
+}
+
+impl Source for AnySource {}

--- a/tests/style_conversion.rs
+++ b/tests/style_conversion.rs
@@ -5,7 +5,8 @@ use std::num::NonZeroU32;
 use std::path::PathBuf;
 
 use maplibre_native::{
-    AnyLayer, CameraUpdate, GeoJson, GeoJsonSource, ImageRendererBuilder, LatLng, StyleError,
+    AnyLayer, AnySource, CameraUpdate, GeoJson, GeoJsonSource, ImageRendererBuilder, LatLng,
+    StyleError,
 };
 
 fn fixture_path(name: &str) -> PathBuf {
@@ -57,6 +58,37 @@ fn from_json_str_reports_json_parse_error() {
 }
 
 #[test]
+fn source_from_json_str_parses_source() {
+    let source = AnySource::from_json_str(
+        "shapes",
+        r#"{
+            "type": "geojson",
+            "data": {
+                "type": "FeatureCollection",
+                "features": []
+            }
+        }"#,
+    )
+    .expect("parse should succeed");
+
+    assert_eq!(source.source_id(), "shapes");
+}
+
+#[test]
+fn source_from_json_str_rejects_invalid_source_json() {
+    let err = AnySource::from_json_str("broken", r#"{ "data": {} }"#)
+        .expect_err("missing type must error");
+    assert!(matches!(err, StyleError::Native(_)), "unexpected error: {err:?}");
+}
+
+#[test]
+fn source_from_json_str_reports_json_parse_error() {
+    let err = AnySource::from_json_str("broken", "this is not json")
+        .expect_err("invalid JSON must error");
+    assert!(matches!(err, StyleError::Json(_)), "unexpected error: {err:?}");
+}
+
+#[test]
 fn add_opaque_layer_from_json_renders() {
     let mut renderer = ImageRendererBuilder::new()
         .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
@@ -100,6 +132,66 @@ fn add_opaque_layer_from_json_renders() {
         a >= 250 && i32::from(b) > i32::from(r) + 20 && i32::from(b) > i32::from(g) + 20
     });
     assert!(saw_blue, "added opaque background layer did not render");
+}
+
+#[test]
+fn add_source_and_layer_from_json_renders() {
+    let mut renderer = ImageRendererBuilder::new()
+        .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
+        .with_pixel_ratio(1.0)
+        .build_static_renderer();
+    renderer
+        .load_style_from_path(fixture_path("test-style.json"))
+        .expect("test style path is valid")
+        .wait()
+        .expect("style loaded");
+
+    let mut style = renderer.style();
+    let source = AnySource::from_json_str(
+        "json-shapes",
+        r#"{
+            "type": "geojson",
+            "data": {
+                "type": "FeatureCollection",
+                "features": [{
+                    "type": "Feature",
+                    "properties": {},
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[
+                            [-45.0, -45.0],
+                            [45.0, -45.0],
+                            [45.0, 45.0],
+                            [-45.0, 45.0],
+                            [-45.0, -45.0]
+                        ]]
+                    }
+                }]
+            }
+        }"#,
+    )
+    .expect("source should parse");
+    style.add_source(source).expect("source added");
+
+    let layer = AnyLayer::from_json_str(
+        r##"{
+            "id": "json-shapes-fill",
+            "type": "fill",
+            "source": "json-shapes",
+            "paint": { "fill-color": "#00ff00", "fill-opacity": 1.0 }
+        }"##,
+    )
+    .expect("layer should parse");
+    style.add_layer(layer).expect("layer added");
+
+    let camera =
+        CameraUpdate::new().center(LatLng { lat: 0.0, lng: 0.0 }).zoom(1.0).bearing(0.0).pitch(0.0);
+    let image = renderer.render_static(&camera).expect("render");
+    let saw_green = image.as_image().pixels().any(|p| {
+        let [r, g, _b, a] = p.0;
+        a >= 250 && i32::from(g) > i32::from(r) + 20
+    });
+    assert!(saw_green, "added JSON source/layer did not render");
 }
 
 #[test]


### PR DESCRIPTION
Adds `AnySource::from_json_value` and `AnySource::from_json_str`, the source counterpart to JSON layer conversion in #205.