### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/maplibre/maplibre-native-rs/compare/v0.8.1...v0.8.2) - 2026-06-08
+
+### Added
+
+- *(style)* add JSON source conversion ([#227](https://github.com/maplibre/maplibre-native-rs/pull/227))
+
+### Other
+
+- *(deps)* bump the all-actions-version-updates group with 2 updates ([#231](https://github.com/maplibre/maplibre-native-rs/pull/231))
+- don't configure glfw demo app and its x11 dependency ([#226](https://github.com/maplibre/maplibre-native-rs/pull/226))
+- forward `MLN_CMAKE_CXX_LAUNCHER` to cmake for ccache integration ([#224](https://github.com/maplibre/maplibre-native-rs/pull/224))
+
 ## [0.8.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.8.0...v0.8.1) - 2026-06-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.8.1"
+version = "0.8.2"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -80,7 +80,7 @@ geojson = "1.0.0"
 image = "0.25"
 insta = "1.43"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.8.1" }
+maplibre_native = { path = ".", version = "0.8.2" }
 serde_json = "1.0"
 tar = "0.4.44"
 thiserror = "2.0.16"


### PR DESCRIPTION



## 🤖 New release

* `maplibre_native`: 0.8.1 -> 0.8.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.2](https://github.com/maplibre/maplibre-native-rs/compare/v0.8.1...v0.8.2) - 2026-06-08

### Added

- *(style)* add JSON source conversion ([#227](https://github.com/maplibre/maplibre-native-rs/pull/227))

### Other

- *(deps)* bump the all-actions-version-updates group with 2 updates ([#231](https://github.com/maplibre/maplibre-native-rs/pull/231))
- don't configure glfw demo app and its x11 dependency ([#226](https://github.com/maplibre/maplibre-native-rs/pull/226))
- forward `MLN_CMAKE_CXX_LAUNCHER` to cmake for ccache integration ([#224](https://github.com/maplibre/maplibre-native-rs/pull/224))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).