### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3](https://github.com/maplibre/maplibre-native-rs/compare/v0.8.2...v0.8.3) - 2026-06-19
+
+### Added
+
+- support OpenGL EGL and GLX contexts ([#230](https://github.com/maplibre/maplibre-native-rs/pull/230))
+
+### Fixed
+
+- *(build)* restore precompiled MLN builds ([#242](https://github.com/maplibre/maplibre-native-rs/pull/242))
+- *(package)* make webgpu-shim publishable ([#241](https://github.com/maplibre/maplibre-native-rs/pull/241))
+
+### Other
+
+- *(deps)* bump toml to 1.1 ([#244](https://github.com/maplibre/maplibre-native-rs/pull/244))
+- cancel superseded CI runs on the same PR ([#240](https://github.com/maplibre/maplibre-native-rs/pull/240))
+- enable ccache for C++ builds on PRs ([#238](https://github.com/maplibre/maplibre-native-rs/pull/238))
+- reduce MSRV job matrix ([#239](https://github.com/maplibre/maplibre-native-rs/pull/239))
+- Implement wgpu Texture sharing
+- *(deps)* bump the all-actions-version-updates group with 2 updates ([#235](https://github.com/maplibre/maplibre-native-rs/pull/235))
+
 ## [0.8.2](https://github.com/maplibre/maplibre-native-rs/compare/v0.8.1...v0.8.2) - 2026-06-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.8.2"
+version = "0.8.3"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -92,7 +92,7 @@ geojson = "1.0.0"
 image = "0.25"
 insta = "1.43"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.8.2" }
+maplibre_native = { path = ".", version = "0.8.3" }
 serde_json = "1.0"
 tar = "0.4.44"
 thiserror = "2.0.16"

--- a/webgpu-shim/CHANGELOG.md
+++ b/webgpu-shim/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.1.0...v0.1.1) - 2026-06-19
+
+### Fixed
+
+- *(package)* make webgpu-shim publishable ([#241](https://github.com/maplibre/maplibre-native-rs/pull/241))

--- a/webgpu-shim/Cargo.toml
+++ b/webgpu-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webgpu-shim"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Webgpu shim based on wgpu"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `webgpu-shim`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `maplibre_native`: 0.8.2 -> 0.8.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `webgpu-shim`

<blockquote>

## [0.1.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.1.0...v0.1.1) - 2026-06-19

### Fixed

- *(package)* make webgpu-shim publishable ([#241](https://github.com/maplibre/maplibre-native-rs/pull/241))
</blockquote>

## `maplibre_native`

<blockquote>

## [0.8.3](https://github.com/maplibre/maplibre-native-rs/compare/v0.8.2...v0.8.3) - 2026-06-19

### Added

- support OpenGL EGL and GLX contexts ([#230](https://github.com/maplibre/maplibre-native-rs/pull/230))

### Fixed

- *(build)* restore precompiled MLN builds ([#242](https://github.com/maplibre/maplibre-native-rs/pull/242))
- *(package)* make webgpu-shim publishable ([#241](https://github.com/maplibre/maplibre-native-rs/pull/241))

### Other

- *(deps)* bump toml to 1.1 ([#244](https://github.com/maplibre/maplibre-native-rs/pull/244))
- cancel superseded CI runs on the same PR ([#240](https://github.com/maplibre/maplibre-native-rs/pull/240))
- enable ccache for C++ builds on PRs ([#238](https://github.com/maplibre/maplibre-native-rs/pull/238))
- reduce MSRV job matrix ([#239](https://github.com/maplibre/maplibre-native-rs/pull/239))
- Implement wgpu Texture sharing
- *(deps)* bump the all-actions-version-updates group with 2 updates ([#235](https://github.com/maplibre/maplibre-native-rs/pull/235))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).