### PR TITLE
feat: add WebGPU (wgpu) rendering backend (Linux x64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
           #   backend: vulkan
           #   precompiled: 1
           #   amalgam: 1
+          # WebGPU (wgpu) ships only as a prebuilt Linux x64 amalgam, so it is
+          # exercised through the precompiled path.
+          - runs-on: ubuntu-latest
+            backend: webgpu
+            precompiled: 1
+            amalgam: 1
           - runs-on: ubuntu-latest
             backend: opengl
             precompiled: 0
@@ -83,8 +89,13 @@ jobs:
       - name: Run CI tests (Linux OpenGL via Xvfb)
         if: startsWith(matrix.runs-on, 'ubuntu') && matrix.backend == 'opengl'
         run: xvfb-run -a --server-args="-screen 0 1280x1024x24" just ci-test ${{ matrix.backend }}
+      # WebGPU ships only as a headless Linux x64 amalgam, and the windowed
+      # examples pin a different backend, so test the library crate only.
+      - name: Run CI tests (WebGPU library only via Xvfb)
+        if: matrix.backend == 'webgpu'
+        run: xvfb-run -a --server-args="-screen 0 1280x1024x24" just ci-test-lib ${{ matrix.backend }}
       - name: Run CI tests
-        if: ${{ !(startsWith(matrix.runs-on, 'ubuntu') && matrix.backend == 'opengl') }}
+        if: ${{ !(startsWith(matrix.runs-on, 'ubuntu') && matrix.backend == 'opengl') && matrix.backend != 'webgpu' }}
         run: just ci-test ${{ matrix.backend }}
 
   test-msrv:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,15 @@ repo = "maplibre/maplibre-native"
 # This version is used only if maplibre-native-rs is build with prebuilt
 # maplibre-native binaries. It is not used when building maplibre-native from source.
 # When building from source, the version of maplibre-native is specified in the `build.rs` file
-release = "core-cc8aa6fe74564180e2eed277dabd2043907c7fd8"
+release = "core-fa8a9c8e3261ce64940127aecc1d52f540c21c57"
 
 [features]
 default = ["log", "json", "geojson"]
 metal = []
 opengl = []
 vulkan = []
+# WebGPU via wgpu-native. Currently only a prebuilt Linux x64 amalgam is available.
+webgpu = []
 # Enables parsing style-spec layer JSON via `AnyLayer::from_json_str`/`from_json_value`.
 json = ["dep:serde_json"]
 geojson = ["dep:geojson"]

--- a/build.rs
+++ b/build.rs
@@ -41,6 +41,9 @@ enum GraphicsRenderingAPI {
     OpenGL,
     /// [Vulkan API](https://www.vulkan.org/)
     Vulkan,
+    /// [WebGPU](https://www.w3.org/TR/webgpu/) via the wgpu-native backend.
+    /// Currently only available as a prebuilt Linux x64 amalgam.
+    WebGPU,
 }
 impl GraphicsRenderingAPI {
     /// Selects the rendering API based on enabled cargo features and platform.
@@ -48,30 +51,33 @@ impl GraphicsRenderingAPI {
     /// - If one feature is enabled, it is used.
     /// - If none are enabled, defaults to Metal on macOS/iOS, Vulkan elsewhere.
     /// - If multiple are enabled, falls back to OpenGL > Metal > Vulkan, with a warning.
+    ///   `webgpu` is never selected as a fallback; it must be requested explicitly.
     fn from_selected_features() -> Self {
         let with_opengl = env::var("CARGO_FEATURE_OPENGL").is_ok();
         let with_metal = env::var("CARGO_FEATURE_METAL").is_ok();
         let with_vulkan = env::var("CARGO_FEATURE_VULKAN").is_ok();
+        let with_webgpu = env::var("CARGO_FEATURE_WEBGPU").is_ok();
 
         let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
         let is_macos = target_os == "ios" || target_os == "macos";
 
-        match (with_metal, with_vulkan, with_opengl) {
-            (true, false, false) => Self::Metal,
-            (false, true, false) => Self::Vulkan,
-            (false, false, true) => Self::OpenGL,
-            (false, false, false) => {
+        match (with_metal, with_vulkan, with_opengl, with_webgpu) {
+            (true, false, false, false) => Self::Metal,
+            (false, true, false, false) => Self::Vulkan,
+            (false, false, true, false) => Self::OpenGL,
+            (false, false, false, true) => Self::WebGPU,
+            (false, false, false, false) => {
                 if is_macos {
                     Self::Metal
                 } else {
                     Self::Vulkan
                 }
             }
-            (_, _, _) => {
+            (_, _, _, _) => {
                 // TODO: modify for better defaults
                 // This might not be the best logic, but it can change at any moment because it's a fallback with a warning
                 // Current logic: if opengl is enabled, always use that, otherwise pick metal on macOS and vulkan on other platforms
-                println!("cargo::warning=Features 'metal', 'opengl', and 'vulkan' are mutually exclusive.");
+                println!("cargo::warning=Features 'metal', 'opengl', 'vulkan', and 'webgpu' are mutually exclusive.");
 
                 let default_choice = if with_opengl {
                     Self::OpenGL
@@ -92,6 +98,8 @@ impl std::fmt::Display for GraphicsRenderingAPI {
             Self::Metal => f.write_str("metal"),
             Self::OpenGL => f.write_str("opengl"),
             Self::Vulkan => f.write_str("vulkan"),
+            // Must match the wgpu amalgam asset suffix (libmaplibre-native-core-amalgam-linux-x64-wgpu.a).
+            Self::WebGPU => f.write_str("wgpu"),
         }
     }
 }
@@ -389,7 +397,14 @@ fn build_local(
             #[cfg(target_os = "linux")]
             // Vulkan has no X11 dependency.
             config.configure_arg("-DMLN_WITH_X11=OFF");
-        } //GraphicsRenderingAPI::WebGPU => config.configure_arg("-DMLN_WITH_WEBGPU=ON").configure_arg("-DMLN_WEBGPU_IMPL_WGPU=ON"),
+        }
+        GraphicsRenderingAPI::WebGPU => {
+            config.configure_arg("-DMLN_WITH_WEBGPU=ON");
+            config.configure_arg("-DMLN_WEBGPU_IMPL_WGPU=ON");
+            #[cfg(target_os = "linux")]
+            // Headless WebGPU does not need X11.
+            config.configure_arg("-DMLN_WITH_X11=OFF");
+        }
     }
     if amalgam_lib {
         config.configure_arg("-DMLN_CREATE_AMALGAMATION:BOOL=ON");
@@ -561,6 +576,17 @@ fn build_mln() {
             println!("cargo:rustc-link-lib=framework=ImageIO");
         }
         GraphicsRenderingAPI::Vulkan => {}
+        // wgpu-native itself is bundled into the amalgam and dlopens the Vulkan
+        // loader at runtime. The prebuilt Linux x64 wgpu amalgam additionally
+        // pulls in maplibre's GLX/X11 platform code and libuv, which are system
+        // libraries that are not bundled and must be linked here.
+        GraphicsRenderingAPI::WebGPU => {
+            if cfg!(target_os = "linux") {
+                println!("cargo:rustc-link-lib=uv");
+                println!("cargo:rustc-link-lib=GL");
+                println!("cargo:rustc-link-lib=X11");
+            }
+        }
         GraphicsRenderingAPI::OpenGL => {
             println!("cargo:rustc-link-lib=GL");
             if cfg!(target_os = "linux") {

--- a/justfile
+++ b/justfile
@@ -31,6 +31,16 @@ ci-lint: env-info test-fmt clippy
 # Run all tests as expected by CI
 ci-test backend: (env-info) (build backend) (test backend) (test-doc backend) (test-example_slint backend) && assert-git-is-clean
 
+# Like `ci-test`, but scoped to the library crate and its integration tests
+# (`-p maplibre_native`). Use for backends whose example binaries are not
+# buildable: the windowed examples in `examples/*` pin a windowed backend
+# (vulkan/metal), so the headless-only WebGPU amalgam cannot build the whole
+# workspace under `--features webgpu`.
+ci-test-lib backend: (env-info) && assert-git-is-clean
+    cargo build -p maplibre_native --features {{backend}} --all-targets
+    cargo test -p maplibre_native --features {{backend}} --all-targets
+    DOCS_RS=1 cargo doc -p maplibre_native --no-deps --features {{backend}}
+
 # Run minimal subset of tests to ensure compatibility with MSRV
 ci-test-msrv backend: (ci-test backend)  # for now, same as ci-test
 
@@ -90,7 +100,7 @@ get-msrv package=main_crate:  (get-crate-field 'rust_version' package)
 install-dependencies backend='vulkan':
     sudo apt-get update
     sudo apt-get install -y \
-      {{if backend == 'opengl' {'libgl1-mesa-dev libglu1-mesa-dev libx11-dev xvfb'} else if backend == 'vulkan' {'mesa-vulkan-drivers glslang-dev'} else {''} }} \
+      {{if backend == 'opengl' {'libgl1-mesa-dev libglu1-mesa-dev libx11-dev xvfb'} else if backend == 'vulkan' {'mesa-vulkan-drivers glslang-dev'} else if backend == 'webgpu' {'libgl1-mesa-dev libglu1-mesa-dev libx11-dev xvfb mesa-vulkan-drivers'} else {''} }} \
       build-essential \
       libcurl4-openssl-dev \
       libuv1-dev \

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -75,8 +75,13 @@ pub mod geojson {
         fn parse(json: &str) -> Result<UniquePtr<GeoJson>>;
         /// Copies a MapLibre Native GeoJSON value.
         fn clone(geojson: &GeoJson) -> UniquePtr<GeoJson>;
-        /// Serializes a MapLibre Native GeoJSON value to a JSON string.
-        fn stringify(geojson: &GeoJson) -> Result<String>;
+        // TEMP(webgpu amalgam): commented out (not deleted) for easy restore.
+        // `mapbox::geojson::stringify` is not exported by the precompiled core
+        // amalgam (armerge keeps only `mbgl.*`) and MapLibre Native has no public
+        // `mbgl::*` GeoJSON serializer yet. Restore with the C++ side and
+        // `GeoJson::to_json_string`.
+        // /// Serializes a MapLibre Native GeoJSON value to a JSON string.
+        // fn stringify(geojson: &GeoJson) -> Result<String>;
     }
 }
 

--- a/src/cpp/geojson/geojson.cpp
+++ b/src/cpp/geojson/geojson.cpp
@@ -1,5 +1,9 @@
 #include "geojson.h"
 
+#include <mbgl/style/conversion/geojson.hpp>
+
+#include <optional>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -12,15 +16,29 @@ const mapbox::geojson::geojson& GeoJson::get() const {
 }
 
 std::unique_ptr<GeoJson> parse(rust::Str json) {
-    return std::make_unique<GeoJson>(mapbox::geojson::parse(std::string(json)));
+    // Use MapLibre's public conversion API (`mbgl::*`) rather than the bundled
+    // geojson-cpp `mapbox::geojson::parse`: the precompiled core amalgam is built
+    // with `armerge --keep-symbols 'mbgl.*'`, which localizes every non-mbgl
+    // symbol, so mapbox::geojson::parse is not linkable by downstream consumers.
+    mbgl::style::conversion::Error error;
+    std::optional<mbgl::GeoJSON> result =
+        mbgl::style::conversion::parseGeoJSON(std::string(json), error);
+    if (!result) {
+        throw std::runtime_error(error.message);
+    }
+    return std::make_unique<GeoJson>(std::move(*result));
 }
 
 std::unique_ptr<GeoJson> clone(const GeoJson& geojson) {
     return std::make_unique<GeoJson>(geojson.get());
 }
 
-rust::String stringify(const GeoJson& geojson) {
-    return mapbox::geojson::stringify(geojson.get());
-}
+// TEMP(webgpu amalgam): commented out (not deleted) for easy restore.
+// `mapbox::geojson::stringify` is localized by the amalgam's
+// `armerge --keep-symbols 'mbgl.*'`, and MapLibre Native exposes no public
+// `mbgl::*` GeoJSON serializer yet. Restore once one is available upstream.
+// rust::String stringify(const GeoJson& geojson) {
+//     return mapbox::geojson::stringify(geojson.get());
+// }
 
 } // namespace mln::bridge::geojson

--- a/src/cpp/geojson/geojson.h
+++ b/src/cpp/geojson/geojson.h
@@ -20,6 +20,7 @@ std::unique_ptr<GeoJson> parse(rust::Str json);
 
 std::unique_ptr<GeoJson> clone(const GeoJson& geojson);
 
-rust::String stringify(const GeoJson& geojson);
+// TEMP(webgpu amalgam): see geojson.cpp. Restore alongside the bridge binding.
+// rust::String stringify(const GeoJson& geojson);
 
 } // namespace mln::bridge::geojson

--- a/src/cpp/style_value.cpp
+++ b/src/cpp/style_value.cpp
@@ -2,7 +2,7 @@
 
 #include <mbgl/style/conversion/layer.hpp>
 #include <mbgl/style/conversion/source.hpp>
-#include <mapbox/geojson.hpp>
+#include <mbgl/style/conversion/geojson.hpp>
 
 #include <iomanip>
 #include <locale>
@@ -171,7 +171,10 @@ std::unique_ptr<mbgl::style::Source> source_from_value(rust::Str id,
 std::optional<mbgl::GeoJSON> style_value_to_geojson(const StyleValue& value,
                                                     mbgl::style::conversion::Error& error) {
     try {
-        return mapbox::geojson::parse(stringify_style_value(value));
+        // Use the public `mbgl::*` conversion API instead of the bundled
+        // mapbox::geojson::parse, which the precompiled amalgam does not export
+        // (armerge keeps only `mbgl.*`).
+        return mbgl::style::conversion::parseGeoJSON(stringify_style_value(value), error);
     } catch (const std::exception& ex) {
         error.message = ex.what();
         return std::nullopt;

--- a/src/style/geojson.rs
+++ b/src/style/geojson.rs
@@ -54,14 +54,22 @@ impl GeoJson {
         Self::from_json_str(&json)
     }
 
-    /// Serializes this value to a GeoJSON string using MapLibre Native.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if MapLibre Native fails to serialize the value.
-    pub fn to_json_string(&self) -> Result<String, GeoJsonError> {
-        geojson::stringify(&self.inner).map_err(|error| GeoJsonError::Native(error.to_string()))
-    }
+    // TEMP(webgpu amalgam): commented out (not deleted) for easy restore.
+    // `geojson::stringify` calls `mapbox::geojson::stringify`, which the
+    // precompiled core amalgam does not export (armerge keeps only `mbgl.*`), and
+    // MapLibre Native exposes no public `mbgl::*` GeoJSON serializer yet. The
+    // render path does not use this (only `as_inner` hands the value to MapLibre).
+    // Restore once an `mbgl::*` stringify exists upstream (re-enable the
+    // `stringify` cxx binding too).
+    //
+    // /// Serializes this value to a GeoJSON string using MapLibre Native.
+    // ///
+    // /// # Errors
+    // ///
+    // /// Returns an error if MapLibre Native fails to serialize the value.
+    // pub fn to_json_string(&self) -> Result<String, GeoJsonError> {
+    //     geojson::stringify(&self.inner).map_err(|error| GeoJsonError::Native(error.to_string()))
+    // }
 
     pub(crate) fn as_inner(&self) -> &geojson::GeoJson {
         self.inner.as_ref().expect("GeoJson bridge value is unexpectedly null")
@@ -113,14 +121,8 @@ mod tests {
     use super::GeoJson;
 
     #[test]
-    fn parse_clone_and_stringify_geojson() {
-        let geojson = r#"{"type":"Point","coordinates":[1.0,2.0]}"#
-            .parse::<GeoJson>()
-            .expect("valid point GeoJSON should parse");
-        let cloned = geojson.clone();
-        let serialized = cloned.to_json_string().expect("valid GeoJSON should serialize");
-
-        assert!(serialized.contains(r#""Point""#));
+    fn parses_valid_geojson() {
+        assert!(r#"{"type":"Point","coordinates":[1.0,2.0]}"#.parse::<GeoJson>().is_ok());
     }
 
     #[test]
@@ -128,58 +130,64 @@ mod tests {
         assert!("not json".parse::<GeoJson>().is_err());
     }
 
-    #[test]
-    fn from_str_drops_bbox_like_maplibre_native() {
-        let geojson = r#"{"type":"Point","bbox":[0,0,1,1],"coordinates":[1.0,2.0]}"#
-            .parse::<GeoJson>()
-            .expect("valid point GeoJSON should parse");
-
-        assert!(!geojson.to_json_string().expect("GeoJSON should serialize").contains("bbox"));
-    }
-
-    #[test]
-    fn from_str_drops_z_coordinates_like_maplibre_native() {
-        let geojson = r#"{"type":"Point","coordinates":[1.0,2.0,12345.6789]}"#
-            .parse::<GeoJson>()
-            .expect("valid 3D point GeoJSON should parse");
-        let serialized = geojson.to_json_string().expect("GeoJSON should serialize");
-        let json: serde_json::Value =
-            serde_json::from_str(&serialized).expect("serialized GeoJSON should parse as JSON");
-        let coordinates = json
-            .get("coordinates")
-            .and_then(serde_json::Value::as_array)
-            .expect("serialized point should have coordinate array");
-
-        assert_eq!(coordinates.len(), 2);
-    }
-
-    #[test]
-    fn clone_survives_original_drop() {
-        let cloned = {
-            let geojson = r#"{"type":"Point","coordinates":[1.0,2.0]}"#
-                .parse::<GeoJson>()
-                .expect("valid point GeoJSON should parse");
-            geojson.clone()
-        };
-
-        assert!(cloned
-            .to_json_string()
-            .expect("cloned GeoJSON should serialize")
-            .contains("Point"));
-    }
-
     #[cfg(feature = "geojson")]
     #[test]
     fn converts_from_geojson_crate_value() {
-        let geojson = r#"{"type":"Feature","geometry":null,"properties":{"name":"empty"}}"#
+        let value = r#"{"type":"Feature","geometry":null,"properties":{"name":"empty"}}"#
             .parse::<::geojson::GeoJson>()
             .expect("valid geojson crate value should parse");
-        let converted = GeoJson::try_from(geojson)
-            .expect("geojson crate value should convert to MapLibre GeoJSON");
-
-        assert!(converted
-            .to_json_string()
-            .expect("converted GeoJSON should serialize")
-            .contains(r#""Feature""#));
+        assert!(GeoJson::try_from(value).is_ok());
     }
+
+    // TEMP(webgpu amalgam): the assertions below were commented out (not deleted)
+    // for easy restore. They depend on `GeoJson::to_json_string`, which is
+    // disabled until MapLibre Native exposes a public `mbgl::*` GeoJSON
+    // serializer. Re-enable together with `to_json_string`.
+    //
+    // #[test]
+    // fn parse_clone_and_stringify_geojson() {
+    //     let geojson = r#"{"type":"Point","coordinates":[1.0,2.0]}"#
+    //         .parse::<GeoJson>()
+    //         .expect("valid point GeoJSON should parse");
+    //     let cloned = geojson.clone();
+    //     let serialized = cloned.to_json_string().expect("valid GeoJSON should serialize");
+    //     assert!(serialized.contains(r#""Point""#));
+    // }
+    //
+    // #[test]
+    // fn from_str_drops_bbox_like_maplibre_native() {
+    //     let geojson = r#"{"type":"Point","bbox":[0,0,1,1],"coordinates":[1.0,2.0]}"#
+    //         .parse::<GeoJson>()
+    //         .expect("valid point GeoJSON should parse");
+    //     assert!(!geojson.to_json_string().expect("GeoJSON should serialize").contains("bbox"));
+    // }
+    //
+    // #[test]
+    // fn from_str_drops_z_coordinates_like_maplibre_native() {
+    //     let geojson = r#"{"type":"Point","coordinates":[1.0,2.0,12345.6789]}"#
+    //         .parse::<GeoJson>()
+    //         .expect("valid 3D point GeoJSON should parse");
+    //     let serialized = geojson.to_json_string().expect("GeoJSON should serialize");
+    //     let json: serde_json::Value =
+    //         serde_json::from_str(&serialized).expect("serialized GeoJSON should parse as JSON");
+    //     let coordinates = json
+    //         .get("coordinates")
+    //         .and_then(serde_json::Value::as_array)
+    //         .expect("serialized point should have coordinate array");
+    //     assert_eq!(coordinates.len(), 2);
+    // }
+    //
+    // #[test]
+    // fn clone_survives_original_drop() {
+    //     let cloned = {
+    //         let geojson = r#"{"type":"Point","coordinates":[1.0,2.0]}"#
+    //             .parse::<GeoJson>()
+    //             .expect("valid point GeoJSON should parse");
+    //         geojson.clone()
+    //     };
+    //     assert!(cloned
+    //         .to_json_string()
+    //         .expect("cloned GeoJSON should serialize")
+    //         .contains("Point"));
+    // }
 }


### PR DESCRIPTION
## Launch Checklist

- [x] Confirm **changes do not include backports from Mapbox projects** — this PR only uses MapLibre Native's public `mbgl::*` API plus this crate's own bridge code.
- [x] Briefly describe the changes (below).
- [x] Link to related issues (below).
- [ ] Before/after visuals — N/A, no visual change; this adds a headless backend.
- [x] Write tests — adds a `webgpu` CI lane that links **and renders** against the released amalgam.
- [x] Document changes to public APIs — `GeoJson::to_json_string` is temporarily removed (see below).
- [ ] Post benchmark scores — N/A.
- [ ] Add a `CHANGELOG.md` entry — skipped; this is an experimental PR (happy to add before merge).

## What this does

Adds a `webgpu` feature that renders through MapLibre Native's wgpu-native backend, consumed as the prebuilt **Linux x64** core amalgam (the other targets do not ship a wgpu amalgam yet).

Background: I added the upstream support for producing that amalgam in maplibre/maplibre-native#4220 (merged). That alone turned out not to be enough to consume it from here, so this PR adds the downstream pieces:

- `build.rs`: a `WebGPU` graphics API behind the `webgpu` feature, selecting the `...-wgpu.a` amalgam and linking the system libraries it pulls in (`uv`, `GL`, `X11`).
- GeoJSON bridge: switch from `mapbox::geojson::parse` to the public `mbgl::style::conversion::parseGeoJSON`.
- CI: a Linux x64 `webgpu` lane (library + integration tests) that links and renders against the released amalgam.

## Why the GeoJSON change (the main point)

The core amalgam is built with `armerge --keep-symbols 'mbgl.*'`, which **intentionally localizes every non-`mbgl` symbol**. So `mapbox::geojson::parse` / `stringify` are hidden, and the amalgam will never export `mapbox::*`. Reaching into the bundled geojson-cpp from this crate therefore cannot link against the precompiled amalgam.

So I would like to propose: **stop depending on `mapbox/geojson.hpp`, and use `mbgl/style/conversion/geojson.hpp` instead.** `parseGeoJSON` is public (`mbgl::*`, exported), so the bridge links cleanly against any backend's amalgam, with no vendoring.

## About `to_json_string` / `stringify`

These were only used in tests. MapLibre Native currently exposes no public `mbgl::*` GeoJSON serializer, so I commented them out (with `TEMP(webgpu amalgam)` markers, trivial to restore). I intend to open a small separate PR to maplibre/maplibre-native adding a public `mbgl` GeoJSON stringify; once that ships, I will restore `to_json_string` cleanly.

## No rush to merge

This is an experimental PR, and **it is totally fine to hold off merging.** The first goal is to show, via this PR's GitHub Actions, that the WebGPU path links and renders. I am happy to discuss the approach (especially the GeoJSON direction) before anything lands.

## Validation

Verified locally on Linux x64 (NVIDIA + llvmpipe): the library and integration tests link against `libmaplibre-native-core-amalgam-linux-x64-wgpu.a` and render with 0 unresolved `wgpu*` symbols.

## Related

- maplibre/maplibre-native#4220 — upstream amalgam support (merged)
- https://github.com/maplibre/maplibre-native/pull/4345 — upstream stringifyGeoJSON support
