### PR TITLE
fix(package): make webgpu-shim publishable

### DIFF
--- a/webgpu-shim/Cargo.toml
+++ b/webgpu-shim/Cargo.toml
@@ -3,6 +3,7 @@ name = "webgpu-shim"
 version = "0.1.0"
 edition = "2024"
 description = "Webgpu shim based on wgpu"
+license.workspace = true
 
 [dependencies]
 cxx = { workspace = true }


### PR DESCRIPTION
release-plz fails on `main` because `webgpu-shim` isn't publishable

failed job: https://github.com/maplibre/maplibre-native-rs/actions/runs/27572147129/job/81541088258