### PR TITLE
fix(build): restore precompiled MLN builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - uses: taiki-e/install-action@db5fb34fa772531a3ece57ca434f579eb334e0fb # v2.75.30
-        with: { tool: 'just' }
+        with: { tool: "just" }
       - run: echo "MLN_PRECOMPILE=${{ matrix.precompiled }}" >> $GITHUB_ENV
       - run: echo "MLN_CORE_LIBRARY_USE_AMALGAM=${{ matrix.amalgam }}" >> $GITHUB_ENV
       - run: just env-info install-dependencies 'wgpu'
@@ -92,8 +92,8 @@ jobs:
           # Linux x86
           - runs-on: ubuntu-latest
             backend: vulkan
-            precompiled: 0
-            amalgam: 0
+            precompiled: 1
+            amalgam: 1
           - runs-on: ubuntu-latest
             backend: opengl
             precompiled: 0
@@ -106,8 +106,8 @@ jobs:
           # macOS ARM
           - runs-on: macos-latest
             backend: metal
-            precompiled: 0
-            amalgam: 0
+            precompiled: 1
+            amalgam: 1
           - runs-on: macos-latest
             backend: vulkan
             precompiled: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,8 @@ jobs:
           # macOS ARM
           - runs-on: macos-latest
             backend: metal
-            precompiled: 1
-            amalgam: 1
+            precompiled: 0
+            amalgam: 0
           - runs-on: macos-latest
             backend: vulkan
             precompiled: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,11 @@ jobs:
           # Linux x86
           - runs-on: ubuntu-latest
             backend: vulkan
-            precompiled: 1
+            precompiled: 0
+            amalgam: 0
+          - runs-on: ubuntu-latest
+            backend: vulkan
+            precompiled: 1 # also cover the prebuilt amalgam path
             amalgam: 1
           - runs-on: ubuntu-latest
             backend: opengl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repo = "maplibre/maplibre-native"
 # This version is used only if maplibre-native-rs is build with prebuilt
 # maplibre-native binaries. It is not used when building maplibre-native from source.
 # When building from source, the version of maplibre-native is specified in the `build.rs` file
-release = "core-cc8aa6fe74564180e2eed277dabd2043907c7fd8"
+release = "core-fa8a9c8e3261ce64940127aecc1d52f540c21c57"
 
 [features]
 default = ["log", "json", "geojson"]

--- a/build.rs
+++ b/build.rs
@@ -641,9 +641,8 @@ fn build_mln() {
         println!("cargo:rustc-link-lib=mbgl-vendor-csscolorparser");
         println!("cargo:rustc-link-lib=mlt-cpp"); // provided with maplibre-native
         if is_apple {
-            // darwin builds vendored ICU and uses the system sqlite3
+            // darwin builds vendored ICU (system sqlite3 is linked below for all darwin builds)
             println!("cargo:rustc-link-lib=mbgl-vendor-icu");
-            println!("cargo:rustc-link-lib=sqlite3");
         } else {
             println!("cargo:rustc-link-lib=mbgl-vendor-nunicode");
             println!("cargo:rustc-link-lib=mbgl-vendor-sqlite");
@@ -675,6 +674,7 @@ fn build_mln() {
     if is_apple {
         println!("cargo:rustc-link-lib=framework=Foundation");
         println!("cargo:rustc-link-lib=framework=CoreGraphics");
+        // darwin uses the system sqlite3 (both source and precompiled builds).
         println!("cargo:rustc-link-lib=sqlite3");
     }
     match backend {

--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,9 @@ const MLN_COMMIT: &str = "35cf39b72f45cfea55a34ffe7358ade5c950a3c5";
 const BRIDGE_RS: &str = "src/bridge.rs";
 const BRIDGE_CPP_DIR: &str = "src/cpp";
 
-const BRIDGE_INCLUDE_DIRS: &[&str] = &["include", "src/cpp"];
+const BRIDGE_INCLUDE_DIRS: &[&str] = &["src/cpp"];
+
+const PRECOMPILED_VENDORED_INCLUDE_DIR: &str = "include";
 
 /// Supported graphics rendering APIs.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -317,7 +319,14 @@ struct Info {
 }
 
 fn bundle_precompiled() -> Info {
-    let (cpp_root, include_dirs) = resolve_mln_core();
+    let (cpp_root, mut include_dirs) = resolve_mln_core();
+
+    // The precompiled headers tarball omits `platform/default/` headers
+    // (e.g. `mbgl/gfx/headless_frontend.hpp`), so add vendored fallbacks.
+    let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    include_dirs.push(root.join(PRECOMPILED_VENDORED_INCLUDE_DIR));
+    // Editing a vendored fallback header must trigger a rebuild of the bridge.
+    println!("cargo:rerun-if-changed={PRECOMPILED_VENDORED_INCLUDE_DIR}");
 
     println!(
         "cargo:warning=Using precompiled maplibre-native static library from {}",

--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,7 @@ const MLN_COMMIT: &str = "35cf39b72f45cfea55a34ffe7358ade5c950a3c5";
 const BRIDGE_RS: &str = "src/bridge.rs";
 const BRIDGE_CPP_DIR: &str = "src/cpp";
 
-const BRIDGE_INCLUDE_DIRS: &[&str] = &[/*"include", */ "src/cpp"];
+const BRIDGE_INCLUDE_DIRS: &[&str] = &["include", "src/cpp"];
 
 /// Supported graphics rendering APIs.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -664,8 +664,10 @@ fn build_mln() {
         }
         println!("cargo:rustc-link-lib=png"); // sudo dnf install libpng-devel
         println!("cargo:rustc-link-lib=jpeg"); // sudo dnf install libjpeg-turbo-devel
-        println!("cargo:rustc-link-lib=uv"); // sudo dnf install libuv-devel
         println!("cargo:rustc-link-lib=webp"); // sudo dnf install libwebp-devel
+    }
+    if !is_apple {
+        println!("cargo:rustc-link-lib=uv"); // sudo dnf install libuv-devel
     }
     println!("cargo:rustc-link-lib=curl");
     println!("cargo:rustc-link-lib=z");

--- a/build.rs
+++ b/build.rs
@@ -675,6 +675,7 @@ fn build_mln() {
     if is_apple {
         println!("cargo:rustc-link-lib=framework=Foundation");
         println!("cargo:rustc-link-lib=framework=CoreGraphics");
+        println!("cargo:rustc-link-lib=sqlite3");
     }
     match backend {
         GraphicsRenderingAPI::Vulkan if is_apple => {

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -75,8 +75,6 @@ pub mod geojson {
         fn parse(json: &str) -> Result<UniquePtr<GeoJson>>;
         /// Copies a MapLibre Native GeoJSON value.
         fn clone(geojson: &GeoJson) -> UniquePtr<GeoJson>;
-        /// Serializes a MapLibre Native GeoJSON value to a JSON string.
-        fn stringify(geojson: &GeoJson) -> Result<String>;
     }
 }
 

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -75,6 +75,10 @@ pub mod geojson {
         fn parse(json: &str) -> Result<UniquePtr<GeoJson>>;
         /// Copies a MapLibre Native GeoJSON value.
         fn clone(geojson: &GeoJson) -> UniquePtr<GeoJson>;
+        // TODO(maplibre-native#4345): can be restored once the precompiled core exposes
+        // a public GeoJSON serializer
+        // /// Serializes a MapLibre Native GeoJSON value to a JSON string.
+        // fn stringify(geojson: &GeoJson) -> Result<String>;
     }
 }
 

--- a/src/cpp/geojson/geojson.cpp
+++ b/src/cpp/geojson/geojson.cpp
@@ -18,7 +18,7 @@ std::unique_ptr<GeoJson> parse(rust::Str json) {
     mbgl::style::conversion::Error error;
     auto geojson = mbgl::style::conversion::parseGeoJSON(std::string(json), error);
     if (!geojson) {
-        throw std::runtime_error(error.message);
+        throw std::runtime_error(error.message.empty() ? "failed to parse GeoJSON" : error.message);
     }
     return std::make_unique<GeoJson>(std::move(*geojson));
 }

--- a/src/cpp/geojson/geojson.cpp
+++ b/src/cpp/geojson/geojson.cpp
@@ -27,4 +27,11 @@ std::unique_ptr<GeoJson> clone(const GeoJson& geojson) {
     return std::make_unique<GeoJson>(geojson.get());
 }
 
+// TODO(maplibre-native#4345): can be restored once the precompiled core exposes a
+// public GeoJSON serializer. `mapbox::geojson::stringify` is localized (hidden) by the
+// amalgam, and maplibre-native#4345 adds `mbgl::style::conversion::stringifyGeoJSON`.
+// rust::String stringify(const GeoJson& geojson) {
+//     return mbgl::style::conversion::stringifyGeoJSON(geojson.get());
+// }
+
 } // namespace mln::bridge::geojson

--- a/src/cpp/geojson/geojson.cpp
+++ b/src/cpp/geojson/geojson.cpp
@@ -1,26 +1,30 @@
 #include "geojson.h"
 
+#include <mbgl/style/conversion/geojson.hpp>
+
+#include <stdexcept>
 #include <string>
 #include <utility>
 
 namespace mln::bridge::geojson {
 
-GeoJson::GeoJson(mapbox::geojson::geojson value) : value_(std::move(value)) {}
+GeoJson::GeoJson(mbgl::GeoJSON value) : value_(std::move(value)) {}
 
-const mapbox::geojson::geojson& GeoJson::get() const {
+const mbgl::GeoJSON& GeoJson::get() const {
     return value_;
 }
 
 std::unique_ptr<GeoJson> parse(rust::Str json) {
-    return std::make_unique<GeoJson>(mapbox::geojson::parse(std::string(json)));
+    mbgl::style::conversion::Error error;
+    auto geojson = mbgl::style::conversion::parseGeoJSON(std::string(json), error);
+    if (!geojson) {
+        throw std::runtime_error(error.message);
+    }
+    return std::make_unique<GeoJson>(std::move(*geojson));
 }
 
 std::unique_ptr<GeoJson> clone(const GeoJson& geojson) {
     return std::make_unique<GeoJson>(geojson.get());
-}
-
-rust::String stringify(const GeoJson& geojson) {
-    return mapbox::geojson::stringify(geojson.get());
 }
 
 } // namespace mln::bridge::geojson

--- a/src/cpp/geojson/geojson.h
+++ b/src/cpp/geojson/geojson.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <mapbox/geojson.hpp>
+#include <mbgl/util/geojson.hpp>
 #include "rust/cxx.h"
 #include <memory>
 
@@ -8,18 +8,16 @@ namespace mln::bridge::geojson {
 
 class GeoJson {
 public:
-    explicit GeoJson(mapbox::geojson::geojson value);
+    explicit GeoJson(mbgl::GeoJSON value);
 
-    const mapbox::geojson::geojson& get() const;
+    const mbgl::GeoJSON& get() const;
 
 private:
-    mapbox::geojson::geojson value_;
+    mbgl::GeoJSON value_;
 };
 
 std::unique_ptr<GeoJson> parse(rust::Str json);
 
 std::unique_ptr<GeoJson> clone(const GeoJson& geojson);
-
-rust::String stringify(const GeoJson& geojson);
 
 } // namespace mln::bridge::geojson

--- a/src/cpp/geojson/geojson.h
+++ b/src/cpp/geojson/geojson.h
@@ -20,4 +20,7 @@ std::unique_ptr<GeoJson> parse(rust::Str json);
 
 std::unique_ptr<GeoJson> clone(const GeoJson& geojson);
 
+// TODO(maplibre-native#4345): can be restored alongside the implementation in geojson.cpp.
+// rust::String stringify(const GeoJson& geojson);
+
 } // namespace mln::bridge::geojson

--- a/src/cpp/style_value.cpp
+++ b/src/cpp/style_value.cpp
@@ -1,8 +1,8 @@
 #include "style_value.h"
 
+#include <mbgl/style/conversion/geojson.hpp>
 #include <mbgl/style/conversion/layer.hpp>
 #include <mbgl/style/conversion/source.hpp>
-#include <mapbox/geojson.hpp>
 
 #include <iomanip>
 #include <locale>
@@ -171,7 +171,7 @@ std::unique_ptr<mbgl::style::Source> source_from_value(rust::Str id,
 std::optional<mbgl::GeoJSON> style_value_to_geojson(const StyleValue& value,
                                                     mbgl::style::conversion::Error& error) {
     try {
-        return mapbox::geojson::parse(stringify_style_value(value));
+        return mbgl::style::conversion::parseGeoJSON(stringify_style_value(value), error);
     } catch (const std::exception& ex) {
         error.message = ex.what();
         return std::nullopt;

--- a/src/style/geojson.rs
+++ b/src/style/geojson.rs
@@ -50,6 +50,17 @@ impl GeoJson {
         Self::from_json_str(&json)
     }
 
+    // TODO(maplibre-native#4345): can be restored once the precompiled core exposes a
+    // public GeoJSON serializer
+    // /// Serializes this value to a GeoJSON string using MapLibre Native.
+    // ///
+    // /// # Errors
+    // ///
+    // /// Returns an error if MapLibre Native fails to serialize the value.
+    // pub fn to_json_string(&self) -> Result<String, GeoJsonError> {
+    //     geojson::stringify(&self.inner).map_err(|error| GeoJsonError::Native(error.to_string()))
+    // }
+
     pub(crate) fn as_inner(&self) -> &geojson::GeoJson {
         self.inner.as_ref().expect("GeoJson bridge value is unexpectedly null")
     }
@@ -127,4 +138,42 @@ mod tests {
 
         let _ = converted.as_inner();
     }
+
+    // TODO(maplibre-native#4345): can be restored once `GeoJson::to_json_string` is
+    // re-enabled (depends on a public `mbgl::*` GeoJSON serializer).
+    // #[test]
+    // fn parse_clone_and_stringify_geojson() {
+    //     let geojson = r#"{"type":"Point","coordinates":[1.0,2.0]}"#
+    //         .parse::<GeoJson>()
+    //         .expect("valid point GeoJSON should parse");
+    //     let cloned = geojson.clone();
+    //     let serialized = cloned.to_json_string().expect("valid GeoJSON should serialize");
+    //
+    //     assert!(serialized.contains(r#""Point""#));
+    // }
+    //
+    // #[test]
+    // fn from_str_drops_bbox_like_maplibre_native() {
+    //     let geojson = r#"{"type":"Point","bbox":[0,0,1,1],"coordinates":[1.0,2.0]}"#
+    //         .parse::<GeoJson>()
+    //         .expect("valid point GeoJSON should parse");
+    //
+    //     assert!(!geojson.to_json_string().expect("GeoJSON should serialize").contains("bbox"));
+    // }
+    //
+    // #[test]
+    // fn from_str_drops_z_coordinates_like_maplibre_native() {
+    //     let geojson = r#"{"type":"Point","coordinates":[1.0,2.0,12345.6789]}"#
+    //         .parse::<GeoJson>()
+    //         .expect("valid 3D point GeoJSON should parse");
+    //     let serialized = geojson.to_json_string().expect("GeoJSON should serialize");
+    //     let json: serde_json::Value =
+    //         serde_json::from_str(&serialized).expect("serialized GeoJSON should parse as JSON");
+    //     let coordinates = json
+    //         .get("coordinates")
+    //         .and_then(serde_json::Value::as_array)
+    //         .expect("serialized point should have coordinate array");
+    //
+    //     assert_eq!(coordinates.len(), 2);
+    // }
 }

--- a/src/style/geojson.rs
+++ b/src/style/geojson.rs
@@ -22,10 +22,6 @@ pub enum GeoJsonError {
 /// A GeoJSON value prepared for MapLibre Native.
 ///
 /// This type owns MapLibre Native's C++ GeoJSON representation.
-///
-/// MapLibre Native's GeoJSON representation is two-dimensional and silently
-/// drops `bbox`, foreign members, and any coordinate beyond X/Y, regardless of
-/// the construction path.
 pub struct GeoJson {
     inner: UniquePtr<geojson::GeoJson>,
 }
@@ -52,15 +48,6 @@ impl GeoJson {
     pub fn from_json_value(value: &serde_json::Value) -> Result<Self, GeoJsonError> {
         let json = serde_json::to_string(value)?;
         Self::from_json_str(&json)
-    }
-
-    /// Serializes this value to a GeoJSON string using MapLibre Native.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if MapLibre Native fails to serialize the value.
-    pub fn to_json_string(&self) -> Result<String, GeoJsonError> {
-        geojson::stringify(&self.inner).map_err(|error| GeoJsonError::Native(error.to_string()))
     }
 
     pub(crate) fn as_inner(&self) -> &geojson::GeoJson {
@@ -113,59 +100,18 @@ mod tests {
     use super::GeoJson;
 
     #[test]
-    fn parse_clone_and_stringify_geojson() {
+    fn parse_and_clone_geojson() {
         let geojson = r#"{"type":"Point","coordinates":[1.0,2.0]}"#
             .parse::<GeoJson>()
             .expect("valid point GeoJSON should parse");
-        let cloned = geojson.clone();
-        let serialized = cloned.to_json_string().expect("valid GeoJSON should serialize");
 
-        assert!(serialized.contains(r#""Point""#));
+        let cloned = geojson.clone();
+        let _ = cloned.as_inner();
     }
 
     #[test]
     fn from_str_reports_invalid_geojson() {
         assert!("not json".parse::<GeoJson>().is_err());
-    }
-
-    #[test]
-    fn from_str_drops_bbox_like_maplibre_native() {
-        let geojson = r#"{"type":"Point","bbox":[0,0,1,1],"coordinates":[1.0,2.0]}"#
-            .parse::<GeoJson>()
-            .expect("valid point GeoJSON should parse");
-
-        assert!(!geojson.to_json_string().expect("GeoJSON should serialize").contains("bbox"));
-    }
-
-    #[test]
-    fn from_str_drops_z_coordinates_like_maplibre_native() {
-        let geojson = r#"{"type":"Point","coordinates":[1.0,2.0,12345.6789]}"#
-            .parse::<GeoJson>()
-            .expect("valid 3D point GeoJSON should parse");
-        let serialized = geojson.to_json_string().expect("GeoJSON should serialize");
-        let json: serde_json::Value =
-            serde_json::from_str(&serialized).expect("serialized GeoJSON should parse as JSON");
-        let coordinates = json
-            .get("coordinates")
-            .and_then(serde_json::Value::as_array)
-            .expect("serialized point should have coordinate array");
-
-        assert_eq!(coordinates.len(), 2);
-    }
-
-    #[test]
-    fn clone_survives_original_drop() {
-        let cloned = {
-            let geojson = r#"{"type":"Point","coordinates":[1.0,2.0]}"#
-                .parse::<GeoJson>()
-                .expect("valid point GeoJSON should parse");
-            geojson.clone()
-        };
-
-        assert!(cloned
-            .to_json_string()
-            .expect("cloned GeoJSON should serialize")
-            .contains("Point"));
     }
 
     #[cfg(feature = "geojson")]
@@ -177,9 +123,6 @@ mod tests {
         let converted = GeoJson::try_from(geojson)
             .expect("geojson crate value should convert to MapLibre GeoJSON");
 
-        assert!(converted
-            .to_json_string()
-            .expect("converted GeoJSON should serialize")
-            .contains(r#""Feature""#));
+        let _ = converted.as_inner();
     }
 }

--- a/src/style/geojson.rs
+++ b/src/style/geojson.rs
@@ -100,12 +100,14 @@ mod tests {
     use super::GeoJson;
 
     #[test]
-    fn parse_and_clone_geojson() {
-        let geojson = r#"{"type":"Point","coordinates":[1.0,2.0]}"#
-            .parse::<GeoJson>()
-            .expect("valid point GeoJSON should parse");
+    fn clone_survives_original_drop() {
+        let cloned = {
+            let geojson = r#"{"type":"Point","coordinates":[1.0,2.0]}"#
+                .parse::<GeoJson>()
+                .expect("valid point GeoJSON should parse");
+            geojson.clone()
+        };
 
-        let cloned = geojson.clone();
         let _ = cloned.as_inner();
     }
 

--- a/tests/image_renderer.rs
+++ b/tests/image_renderer.rs
@@ -88,11 +88,10 @@ fn multiple_renderers_render_on_single_thread() {
     let second_request =
         second.submit_render_static(&test_camera()).expect("second render should submit");
 
-    // Both requests are driven from the same thread-local run loop.
-    tick_until_ready(|| first_request.is_ready() && second_request.is_ready());
-
-    let first_image = first_request.finish().expect("first renderer should render");
-    let second_image = second_request.finish().expect("second renderer should render");
+    // Both requests are already submitted before waiting, so they are driven
+    // from the same thread-local run loop.
+    let first_image = first_request.wait().expect("first renderer should render");
+    let second_image = second_request.wait().expect("second renderer should render");
 
     assert_eq!(first_image.as_image().width(), 128);
     assert_eq!(first_image.as_image().height(), 128);
@@ -108,9 +107,8 @@ fn load_style_from_json_str_renders() {
 
     let request =
         renderer.submit_render_static(&test_camera()).expect("JSON style render should submit");
-    tick_until_ready(|| request.is_ready());
 
-    let image = request.finish().expect("JSON style should render");
+    let image = request.wait().expect("JSON style should render");
     assert_eq!(image.as_image().width(), 128);
     assert_eq!(image.as_image().height(), 128);
 }
@@ -150,9 +148,7 @@ fn tile_render_request_renders() {
 
     let request = renderer.submit_render_tile(0, 0, 0).expect("tile render should submit");
 
-    tick_until_ready(|| request.is_ready());
-
-    let image = request.finish().expect("tile renderer should render");
+    let image = request.wait().expect("tile renderer should render");
     assert_eq!(image.as_image().width(), 128);
     assert_eq!(image.as_image().height(), 128);
 }
@@ -171,9 +167,8 @@ fn camera_for_bounds_renders() {
     };
     let camera = renderer.camera_for_bounds(bounds, Some(EdgeInsets::all(8.0)), 0.0, 0.0);
     let request = renderer.submit_render_static(&camera).expect("bounds-fit render should submit");
-    tick_until_ready(|| request.is_ready());
 
-    let image = request.finish().expect("bounds-fit renderer should render");
+    let image = request.wait().expect("bounds-fit renderer should render");
     assert_eq!(image.as_image().width(), 128);
     assert_eq!(image.as_image().height(), 128);
 }
@@ -197,9 +192,8 @@ fn camera_for_lat_lngs_renders() {
         .expect("non-empty coordinates should produce a camera");
     let request =
         renderer.submit_render_static(&camera).expect("coordinates-fit render should submit");
-    tick_until_ready(|| request.is_ready());
 
-    let image = request.finish().expect("coordinates-fit renderer should render");
+    let image = request.wait().expect("coordinates-fit renderer should render");
     assert_eq!(image.as_image().width(), 128);
     assert_eq!(image.as_image().height(), 128);
 }
@@ -234,9 +228,8 @@ fn camera_for_geojson_renders() {
         .expect("non-empty geometry should produce a camera");
     let request =
         renderer.submit_render_static(&camera).expect("geometry-fit render should submit");
-    tick_until_ready(|| request.is_ready());
 
-    let image = request.finish().expect("geometry-fit renderer should render");
+    let image = request.wait().expect("geometry-fit renderer should render");
     assert_eq!(image.as_image().width(), 128);
     assert_eq!(image.as_image().height(), 128);
 }
@@ -282,8 +275,7 @@ fn camera_for_geojson_matches_bounds() {
 
     let render = |renderer: &mut ImageRenderer<Static>, camera: &CameraUpdate| {
         let request = renderer.submit_render_static(camera).expect("render should submit");
-        tick_until_ready(|| request.is_ready());
-        request.finish().expect("render should succeed").as_image().clone()
+        request.wait().expect("render should succeed").as_image().clone()
     };
 
     let geo_camera = renderer


### PR DESCRIPTION
I found `MLN_PRECOMPILE=1` builds are currently broken, but this was not caught by CI. This PR updates the precompiled MapLibre Native release and fixes the link setup:

(Some of these changes are based on #237 by @yuiseki - thanks!)

- Update the precompiled MLN release to the [latest core release](https://github.com/maplibre/maplibre-native/releases/tag/core-fa8a9c8e3261ce64940127aecc1d52f540c21c57)
- Restore the vendored bridge include path
- Link required system libraries for precompiled builds (`libuv` on non-Apple targets, `sqlite3` on Apple targets)
- Avoid direct `mapbox::geojson` symbols from the Rust bridge, since they are hidden in the amalgam
- Comment out now-unused `GeoJson::to_json_string()` - no public mbgl API yet maplibre/maplibre-native#4345
- Add precompiled CI coverage to prevent regressions

Note: macOS still does not work with `MLN_PRECOMPILE=1` because the amalgam (built with `armerge --keep-symbols 'mbgl.*'`) also hides the C++ exception RTTI symbols.