### PR TITLE
chore(deps): bump toml to 1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ cxx-build.workspace = true
 downloader.workspace = true
 flate2.workspace = true
 tar.workspace = true
-toml = "0.8"
+toml.workspace = true
 walkdir.workspace = true
 webgpu-shim = { workspace = true, optional = true }
 
@@ -91,6 +91,7 @@ serde_json = "1.0"
 tar = "0.4.44"
 thiserror = "2.0.16"
 tokio = { version = "1", features = [], default-features = false }
+toml = "1.1"
 url = "2.5.7"
 walkdir = "2.5.0"
 webgpu-shim = { path = "webgpu-shim" }

--- a/build.rs
+++ b/build.rs
@@ -169,7 +169,7 @@ fn determine_cargo_toml_information() -> CargoTomlInformation {
         panic!("Failed to read manifest at {}: {err}", manifest_path.display())
     });
 
-    let manifest: toml::Value = manifest_str.parse().unwrap_or_else(|err| {
+    let manifest: toml::Value = toml::from_str(&manifest_str).unwrap_or_else(|err| {
         panic!("Failed to parse manifest as TOML at {}: {err}", manifest_path.display())
     });
 


### PR DESCRIPTION
Dependabot keeps opening empty PRs for the `toml` 0.8 → 1.x bump (e.g. #243).