### PR TITLE
fix(package): add a version requirement to the `webgpu-shim` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ tokio = { version = "1", features = [], default-features = false }
 toml = "1.1"
 url = "2.5.7"
 walkdir = "2.5.0"
-webgpu-shim = { path = "webgpu-shim" }
+webgpu-shim = { path = "webgpu-shim", version = "0.1" }
 wgpu = { version = "29.0.0" }
 
 [workspace.lints.rust]


### PR DESCRIPTION
The internal dep `webgpu-shim` has no version requirement, so `maplibre_native` can't be published.

Failed `release-plz` job on `main`: https://github.com/maplibre/maplibre-native-rs/actions/runs/27826992304/job/82360416097