### PR TITLE
fix(ci): stop tagging webgpu-shim releases

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,3 +2,8 @@
 dependencies_update = true
 git_release_name = "v{{ version }}"
 git_tag_name = "v{{ version }}"
+
+[[package]]
+name = "webgpu-shim"
+git_release_enable = false
+git_tag_enable = false

--- a/webgpu-shim/CHANGELOG.md
+++ b/webgpu-shim/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.1] - 2026-06-19
+## 0.1.1 - 2026-06-19
 
 ### Fixed
 

--- a/webgpu-shim/CHANGELOG.md
+++ b/webgpu-shim/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.1.0...v0.1.1) - 2026-06-19
+## [0.1.1] - 2026-06-19
 
 ### Fixed
 


### PR DESCRIPTION
release-plz tries to create `v*.*.*` Git tags for `webgpu-shim`, but those collide with the main MLN-rs release tags and cause release-plz to fail.

I don't think `webgpu-shim` needs its own Git version tags for now.

Example failed job: https://github.com/maplibre/maplibre-native-rs/actions/runs/28109688184/job/83239221959