### PR TITLE
fix(ci): give webgpu-shim its own release-plz tag namespace

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,3 +7,4 @@ git_tag_name = "v{{ version }}"
 name = "webgpu-shim"
 git_release_enable = false
 git_tag_enable = false
+git_tag_name = "webgpu-shim-v{{ version }}"


### PR DESCRIPTION
#251 did not fix the release-plz failure.

My local `release-plz` testing showed that `webgpu-shim` also needs its own `git_tag_name`, even with Git tag creation disabled.