### PR TITLE
fix(build): fix WGPU source builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ use std::process::Command;
 use std::{env, fs};
 
 const MLN_REPOSITORY_URL: &str = "https://github.com/maplibre/maplibre-native.git";
-const MLN_COMMIT: &str = "ad258ded1c4b0e8b2d68f63e90b6538eb02f795a";
+const MLN_COMMIT: &str = "f442c704b806d6f1e64242aa462a31c6f128cf47";
 
 const BRIDGE_RS: &str = "src/bridge.rs";
 const BRIDGE_CPP_DIR: &str = "src/cpp";

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ use std::process::Command;
 use std::{env, fs};
 
 const MLN_REPOSITORY_URL: &str = "https://github.com/maplibre/maplibre-native.git";
-const MLN_COMMIT: &str = "4cfc8a97f75b13f8474b3e5b038bb45b1326747f";
+const MLN_COMMIT: &str = "ad258ded1c4b0e8b2d68f63e90b6538eb02f795a";
 
 const BRIDGE_RS: &str = "src/bridge.rs";
 const BRIDGE_CPP_DIR: &str = "src/cpp";


### PR DESCRIPTION
## Summary

This fixes the `wgpu` source-build path without requiring extra native build dependencies beyond the `mbgl-core` target this crate actually builds.

The native source revision is updated to `7f0f09d1bcf7bfacaad83d15b89f665641781824`, the upstream `maplibre/maplibre-native` commit that contains the WebGPU default-platform include fix from maplibre/maplibre-native#4380.

For Darwin source builds, MapLibre Native CMake configures generated Obj-C SDK style sources through Bazel, even though this crate calls `config.build_target("mbgl-core")` and does not build the Darwin SDK targets. The build script now pre-seeds the CMake `BAZEL` variable with `/usr/bin/true` on Darwin so configuring `mbgl-core` does not require Bazel to be installed. That command is not executed by the `mbgl-core` build target.

## Validation

- `cargo fmt --all`
- `MLN_PRECOMPILE=0 MLN_CORE_LIBRARY_USE_AMALGAM=0 cargo build` in `examples/slint`
- `MLN_PRECOMPILE=0 cargo check --workspace --all-targets --features wgpu`

## Notes

No public Rust API changes.
No Mapbox backports.
No visual changes.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [x] Include before/after visuals or gifs if this PR includes visual changes.
- [x] Write tests for all new functionality.
- [x] Document any changes to public APIs.
- [x] Post benchmark scores.
- [x] Add an entry to `CHANGELOG.md` under the `## main` section.