### PR TITLE
fix(renderer): add missing priority and usage to ResourceRequest

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -813,6 +813,8 @@ pub mod file_source {
         pub kind: ResourceKind,
         pub loading_methods: u8,
         pub is_volatile: bool,
+        pub is_low_priority: bool,
+        pub is_offline: bool,
         pub has_tile: bool,
         pub tile_url_template: String,
         pub tile_pixel_ratio: u8,

--- a/src/cpp/rust_file_source.cpp
+++ b/src/cpp/rust_file_source.cpp
@@ -91,6 +91,8 @@ RawResourceRequest toRustResourceRequest(const mbgl::Resource& resource, bool in
     out.kind = resource.kind;
     out.loading_methods = static_cast<std::uint8_t>(resource.loadingMethod);
     out.is_volatile = resource.storagePolicy == mbgl::Resource::StoragePolicy::Volatile;
+    out.is_low_priority = resource.priority == mbgl::Resource::Priority::Low;
+    out.is_offline = resource.usage == mbgl::Resource::Usage::Offline;
 
     if (resource.tileData) {
         out.has_tile = true;

--- a/src/renderer/file_source/mod.rs
+++ b/src/renderer/file_source/mod.rs
@@ -17,7 +17,7 @@ mod tokio;
 use std::time::{Duration, SystemTime};
 
 pub use crate::bridge::file_source::{ErrorReason, FileSourceType, ResourceKind};
-pub use request::{LoadingMethods, ResourceRequest, StoragePolicy, TileRequest};
+pub use request::{LoadingMethods, Priority, ResourceRequest, StoragePolicy, TileRequest, Usage};
 pub use response::{Error, Response};
 pub use source::{
     register_file_source, CancelHook, FileSource, ForwardCompletion, RequestHandle, Responder,

--- a/src/renderer/file_source/request.rs
+++ b/src/renderer/file_source/request.rs
@@ -19,6 +19,10 @@ pub struct ResourceRequest {
     pub loading_methods: LoadingMethods,
     /// Storage policy requested by MapLibre Native.
     pub storage_policy: StoragePolicy,
+    /// Priority requested by MapLibre Native.
+    pub priority: Priority,
+    /// Whether the request is made for online or offline use.
+    pub usage: Usage,
     /// Tile metadata, present for tile requests.
     pub tile: Option<TileRequest>,
     /// Requested inclusive byte range, present for partial reads.
@@ -46,6 +50,8 @@ impl ResourceRequest {
             } else {
                 StoragePolicy::Permanent
             },
+            priority: if raw.is_low_priority { Priority::Low } else { Priority::Regular },
+            usage: if raw.is_offline { Usage::Offline } else { Usage::Online },
             tile: raw.has_tile.then(|| TileRequest {
                 url_template: raw.tile_url_template.clone(),
                 pixel_ratio: raw.tile_pixel_ratio,
@@ -98,6 +104,26 @@ pub enum StoragePolicy {
     Permanent,
     /// The response should be treated as volatile.
     Volatile,
+}
+
+/// Priority for a resource request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Priority {
+    /// Regular priority.
+    Regular,
+    /// Low priority; the source may defer it or fetch it with less urgency.
+    Low,
+}
+
+/// Usage context for a resource request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Usage {
+    /// The resource is requested for online use.
+    Online,
+    /// The resource is requested for offline use, such as a region download.
+    Offline,
 }
 
 /// Tile metadata attached to tile resource requests.

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -12,8 +12,8 @@ pub use builder::ImageRendererBuilder;
 pub use camera::CameraUpdate;
 pub use file_source::{
     register_file_source, CancelHook, FileSource, FileSourceType, ForwardCompletion,
-    LoadingMethods, RequestHandle, ResourceKind, ResourceRequest, Responder, StoragePolicy,
-    TileRequest,
+    LoadingMethods, Priority, RequestHandle, ResourceKind, ResourceRequest, Responder,
+    StoragePolicy, TileRequest, Usage,
 };
 #[cfg(feature = "tokio")]
 pub use file_source::{


### PR DESCRIPTION
Follow-up to #250.

I simply forgot to include `priority` and `usage` in `ResourceRequest`.