### PR TITLE
fix(renderer): fix mysterious scheduling hang since v0.8.4

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -315,7 +315,12 @@ fn resolve_mln_core() -> (PathBuf, Vec<PathBuf>) {
 }
 
 /// Gather include directories and build the C++ bridge using `cxx_build`.
-fn build_bridge(lib_name: &str, include_dirs: &[PathBuf], backend: GraphicsApi) {
+fn build_bridge(
+    lib_name: &str,
+    include_dirs: &[PathBuf],
+    backend: GraphicsApi,
+    core_uses_ndebug: bool,
+) {
     // println!("cargo:warning=Include_dirs: {:?}", include_dirs);
     let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let bridge_include_dirs: Vec<PathBuf> =
@@ -327,6 +332,12 @@ fn build_bridge(lib_name: &str, include_dirs: &[PathBuf], backend: GraphicsApi) 
         .flag_if_supported("-std=c++20")
         .warnings(true)
         .warnings_into_errors(true);
+
+    // Some public MLN types (notably RunLoop) have NDEBUG-dependent layouts.
+    // Compile inline bridge code with the same ABI layout as the linked core.
+    if core_uses_ndebug {
+        build.define("NDEBUG", None);
+    }
 
     if matches!(backend, GraphicsApi::OpenGl(_)) {
         build.define("MLN_RENDER_BACKEND_OPENGL", Some("1"));
@@ -683,7 +694,17 @@ fn build_mln() {
     };
 
     let backend = GraphicsApi::from_selected_features();
-    build_bridge(&info.lib_name, &info.include_dirs, backend);
+    let source_core_uses_ndebug = match env::var("OPT_LEVEL").as_deref() {
+        Ok("0") => false,
+        Ok("1" | "2" | "3" | "s" | "z") => true,
+        _ => env::var("PROFILE").as_deref() != Ok("debug"),
+    };
+    build_bridge(
+        &info.lib_name,
+        &info.include_dirs,
+        backend,
+        precompiled || source_core_uses_ndebug,
+    );
     let is_apple = target_os == "macos" || target_os == "ios";
     if !amalgam_lib {
         // The dependent libs are not bundled in the core lib, so we have to link manually

--- a/src/cpp/rust_file_source.cpp
+++ b/src/cpp/rust_file_source.cpp
@@ -10,13 +10,13 @@
 #include <mbgl/util/async_request.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/client_options.hpp>
-#include <mbgl/util/run_loop.hpp>
 
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -133,15 +133,16 @@ RawResourceRequest toRustResourceRequest(const mbgl::Resource& resource, bool in
     return out;
 }
 
-// MapLibre Native requires the request callback on the thread that issued request(),
-// so marshal it back to that thread's scheduler rather than calling cb here.
 void completeState(const std::shared_ptr<RequestState>& state, mbgl::Response response) {
-    auto* scheduler = state->scheduler;
-    scheduler->schedule([state, response = std::move(response)]() mutable {
-        if (!state->cancelled.load()) {
-            state->cb(std::move(response));
-        }
-    });
+    if (state->cancelled.load()) {
+        return;
+    }
+
+    {
+        std::scoped_lock lock(state->response_mutex);
+        state->response.emplace(std::move(response));
+    }
+    state->dispatch();
 }
 
 void completeForwardState(const std::shared_ptr<ForwardState>& state) {
@@ -178,7 +179,27 @@ public:
                                                 Callback cb) override {
         auto state = std::make_shared<RequestState>();
         state->cb = std::move(cb);
-        state->scheduler = mbgl::util::RunLoop::Get();
+
+        // FileSource callbacks must run on the thread that issued request().
+        // Capture the scheduler's weak binding while that scheduler is known to
+        // be alive. A late completion becomes a no-op after scheduler teardown.
+        std::weak_ptr<RequestState> weakState = state;
+        state->dispatch = mbgl::Scheduler::GetCurrent()->bindOnce([weakState]() mutable {
+            auto state = weakState.lock();
+            if (!state || state->cancelled.load()) {
+                return;
+            }
+
+            std::optional<mbgl::Response> response;
+            {
+                std::scoped_lock lock(state->response_mutex);
+                response = std::move(state->response);
+                state->response.reset();
+            }
+            if (response && !state->cancelled.load()) {
+                state->cb(std::move(*response));
+            }
+        });
 
         auto request = toRustResourceRequest(resource, true);
         rust::Box<RequestHandleFfi> handle = (**source_).request(request, state);

--- a/src/cpp/rust_file_source.h
+++ b/src/cpp/rust_file_source.h
@@ -11,6 +11,8 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <optional>
 
 namespace mln {
 namespace bridge {
@@ -28,7 +30,9 @@ struct RawResponse;
 // Native state for one in-flight request
 struct RequestState {
   mbgl::FileSource::Callback cb;
-  mbgl::Scheduler *scheduler = nullptr;
+  std::function<void()> dispatch;
+  std::mutex response_mutex;
+  std::optional<mbgl::Response> response;
   std::atomic<bool> cancelled{false};
 };
 


### PR DESCRIPTION
Linux release builds could hang while scheduling renderer work starting with v0.8.4.

Diagnosis with Codex (GPT-5.6-Sol):

- The precompiled MLN core used `NDEBUG`, but the C++ bridge did not, creating a latent ABI mismatch.
- The asynchronous FileSource support added in v0.8.4 exposed this mismatch: at `-O2`, the bridge emitted scheduler code compiled against an incompatible RunLoop layout, corrupting scheduler state.
- This fix aligns `NDEBUG` across the ABI boundary. It also uses `Scheduler::bindOnce()` to make late FileSource completion safe after scheduler teardown.
