### PR TITLE
fix(file_source): pass missing response fields to mbgl

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -881,6 +881,9 @@ pub mod file_source {
         /// Cancel `state` without delivering a response.
         fn responder_cancel(state: SharedPtr<RequestState>);
 
+        #[allow(dead_code)]
+        fn roundtrip_response_for_test(response: &RawResponse) -> RawResponse;
+
         /// Notify mbgl that a cache `forward` call finished.
         fn forward_complete(state: SharedPtr<ForwardState>);
     }

--- a/src/cpp/rust_file_source.cpp
+++ b/src/cpp/rust_file_source.cpp
@@ -28,16 +28,22 @@ namespace {
 mbgl::Response buildResponse(const RawResponse& r) {
     mbgl::Response response;
     if (r.has_error) {
+        std::optional<mbgl::Timestamp> retry_after;
+        if (r.has_retry_after) {
+            retry_after = mbgl::Timestamp(mbgl::Seconds(r.retry_after_epoch_s));
+        }
         response.error = std::make_unique<mbgl::Response::Error>(
-            r.error_reason, std::string(r.error_message));
+            r.error_reason, std::string(r.error_message), retry_after);
     }
     response.noContent = r.no_content;
+    response.notModified = r.not_modified;
+    response.mustRevalidate = r.must_revalidate;
     if (r.has_data) {
         response.data = std::make_shared<std::string>(
             reinterpret_cast<const char*>(r.data.data()), r.data.size());
     }
-    if (r.has_expires) {
-        response.expires = mbgl::Timestamp(mbgl::Seconds(r.modified_epoch_s));
+    if (r.has_modified) {
+        response.modified = mbgl::Timestamp(mbgl::Seconds(r.modified_epoch_s));
     }
     if (r.has_expires) {
         response.expires = mbgl::Timestamp(mbgl::Seconds(r.expires_epoch_s));
@@ -251,6 +257,10 @@ void responder_complete(std::shared_ptr<RequestState> state, const RawResponse& 
 
 void responder_cancel(std::shared_ptr<RequestState> state) {
     state->cancelled.store(true);
+}
+
+RawResponse roundtrip_response_for_test(const RawResponse& response) {
+    return toRustResponse(buildResponse(response));
 }
 
 void forward_complete(std::shared_ptr<ForwardState> state) {

--- a/src/cpp/rust_file_source.h
+++ b/src/cpp/rust_file_source.h
@@ -49,6 +49,8 @@ void responder_complete(std::shared_ptr<RequestState> state,
 
 void responder_cancel(std::shared_ptr<RequestState> state);
 
+RawResponse roundtrip_response_for_test(const RawResponse &response);
+
 void forward_complete(std::shared_ptr<ForwardState> state);
 
 } // namespace bridge

--- a/src/renderer/file_source/response.rs
+++ b/src/renderer/file_source/response.rs
@@ -177,10 +177,13 @@ impl Response {
 mod tests {
     use std::time::{Duration, SystemTime};
 
+    use crate::bridge::file_source::roundtrip_response_for_test;
+
     use super::{ErrorReason, Response};
 
     fn roundtrip(response: Response) -> Response {
-        Response::from_ffi(&response.into_ffi())
+        let raw = roundtrip_response_for_test(&response.into_ffi());
+        Response::from_ffi(&raw)
     }
 
     #[test]


### PR DESCRIPTION
Copies all `Response` fields from Rust into C++ `mbgl::Response`, fixing conditional caching and retry metadata.