### PR TITLE
feat(renderer)!: make continuous rendering host-driven

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -330,6 +330,9 @@ fn build_bridge(
         .includes(&bridge_include_dirs)
         .includes(include_dirs)
         .flag_if_supported("-std=c++20")
+        // mbgl-core defaults to no RTTI (CMake `MLN_WITH_RTTI=OFF` adds `-fno-rtti` on GCC/Clang).
+        // The bridge uses no `dynamic_cast`/`typeid`, so `-fno-rtti` is safe.
+        // (MSVC keeps RTTI on both sides)
         .flag_if_supported("-fno-rtti")
         .warnings(true)
         .warnings_into_errors(true);

--- a/build.rs
+++ b/build.rs
@@ -330,6 +330,7 @@ fn build_bridge(
         .includes(&bridge_include_dirs)
         .includes(include_dirs)
         .flag_if_supported("-std=c++20")
+        .flag_if_supported("-fno-rtti")
         .warnings(true)
         .warnings_into_errors(true);
 

--- a/examples/slint/src/main.rs
+++ b/examples/slint/src/main.rs
@@ -25,11 +25,8 @@ fn main() {
         width: DEFAULT_WIDTH,
         height: DEFAULT_HEIGHT,
     });
-    map.borrow_mut()
-        .renderer()
-        .load_style_from_url(&"https://tiles.openfreemap.org/styles/liberty".parse().unwrap());
-
-    maplibre::init(&ui, &map);
+    // Keep the returned run-loop pump timer alive for the app's lifetime.
+    let _pump_timer = maplibre::init(&ui, &map, "https://tiles.openfreemap.org/styles/liberty");
 
     ui.run().unwrap();
 }

--- a/examples/slint/src/maplibre.rs
+++ b/examples/slint/src/maplibre.rs
@@ -150,7 +150,11 @@ pub fn init(
 
     ui.global::<MapAdapter>().on_mouse_move({
         let map = Rc::downgrade(map);
+        let lifecycle = lifecycle.clone();
         move |x: f32, y: f32, ctrl: bool| {
+            if lifecycle.get() != Lifecycle::Running {
+                return;
+            }
             let p = ScreenCoordinate { x: x.into(), y: y.into() };
             let map = map.upgrade().unwrap();
             let mut map = map.borrow_mut();
@@ -169,7 +173,11 @@ pub fn init(
 
     ui.global::<MapAdapter>().on_wheel_zoom({
         let map = Rc::downgrade(map);
+        let lifecycle = lifecycle.clone();
         move |x: f32, y: f32, delta: f32| {
+            if lifecycle.get() != Lifecycle::Running {
+                return;
+            }
             const STEP: f64 = 1.2;
             const DELTA_PER_STEP: f64 = 60.0;
             let pos = ScreenCoordinate { x: x.into(), y: y.into() };
@@ -180,7 +188,11 @@ pub fn init(
 
     ui.global::<MapAdapter>().on_bearing_changed({
         let map = Rc::downgrade(map);
+        let lifecycle = lifecycle.clone();
         move |delta: f32| {
+            if lifecycle.get() != Lifecycle::Running {
+                return;
+            }
             // MapLibre's rotateBy API expects a gesture from one pointer position to another.
             // Control+wheel provides only a scalar delta, so convert it into a small synthetic drag.
             map.upgrade().unwrap().borrow_mut().rotate_by(delta);
@@ -189,7 +201,11 @@ pub fn init(
 
     ui.global::<MapAdapter>().on_pitch_changed({
         let map = Rc::downgrade(map);
+        let lifecycle = lifecycle.clone();
         move |delta: f32| {
+            if lifecycle.get() != Lifecycle::Running {
+                return;
+            }
             map.upgrade().unwrap().borrow_mut().renderer().pitch_by(delta.into());
         }
     });

--- a/examples/slint/src/maplibre.rs
+++ b/examples/slint/src/maplibre.rs
@@ -19,10 +19,9 @@ enum Lifecycle {
     Stopped,
 }
 
-fn queue_animating(ui: &slint::Weak<MainWindow>, animating: bool) {
-    let _ = ui.upgrade_in_event_loop(move |ui| {
-        ui.global::<MapAdapter>().set_animating(animating);
-    });
+fn queue_frame(ui: &slint::Weak<MainWindow>, frame_requested: &Cell<bool>) {
+    frame_requested.set(true);
+    let _ = ui.upgrade_in_event_loop(|ui| ui.window().request_redraw());
 }
 
 pub fn init(
@@ -32,12 +31,15 @@ pub fn init(
 ) -> Option<slint::Timer> {
     let style_url = style_url.into();
     let lifecycle = Rc::new(Cell::new(Lifecycle::Uninitialized));
+    let frame_requested = Rc::new(Cell::new(false));
 
     ui.window()
         .set_rendering_notifier({
             let map = Rc::downgrade(map);
             let lifecycle = lifecycle.clone();
+            let frame_requested = frame_requested.clone();
             let ui_weak = ui.as_weak();
+            let styled = Cell::new(false);
             move |state, graphics_api| match state {
                 slint::RenderingState::RenderingSetup => {
                     if lifecycle.get() != Lifecycle::Uninitialized {
@@ -55,23 +57,13 @@ pub fn init(
                     map.build_renderer(ui.window().scale_factor());
                     map.renderer().set_device_queue(device.clone(), queue.clone());
 
-                    // MapLibre asks for a frame (input, transitions, async loads);
-                    // going idle stops the clock again.
                     map.renderer().set_render_requested_callback({
                         let lifecycle = lifecycle.clone();
+                        let frame_requested = frame_requested.clone();
                         let ui = ui.as_weak();
                         move || {
                             if lifecycle.get() == Lifecycle::Running {
-                                queue_animating(&ui, true);
-                            }
-                        }
-                    });
-                    map.renderer().map_observer().set_did_become_idle_callback({
-                        let lifecycle = lifecycle.clone();
-                        let ui = ui.as_weak();
-                        move || {
-                            if lifecycle.get() == Lifecycle::Running {
-                                queue_animating(&ui, false);
+                                queue_frame(&ui, &frame_requested);
                             }
                         }
                     });
@@ -80,11 +72,43 @@ pub fn init(
                         &style_url.parse().expect("style URL should be valid"),
                     );
                     lifecycle.set(Lifecycle::Running);
-                    queue_animating(&ui_weak, true);
+                    queue_frame(&ui_weak, &frame_requested);
+                }
+                slint::RenderingState::BeforeRendering => {
+                    if lifecycle.get() != Lifecycle::Running
+                        || !frame_requested.replace(false)
+                    {
+                        return;
+                    }
+
+                    let map = map.upgrade().unwrap();
+                    let mut map = map.borrow_mut();
+                    map.renderer().render_once();
+
+                    if let Some(error) = map.style_loading_error() {
+                        eprintln!("Failed to load map: {error}");
+                        lifecycle.set(Lifecycle::Stopped);
+                        return;
+                    }
+
+                    if map.style_loaded() && !styled.get() {
+                        style(&mut map);
+                        styled.set(true);
+                    }
+
+                    if let Some(image) = map.renderer().take_texture()
+                        && let Ok(image) = image.try_into()
+                    {
+                        ui_weak
+                            .upgrade()
+                            .unwrap()
+                            .global::<MapAdapter>()
+                            .set_map_texture(image);
+                    }
                 }
                 slint::RenderingState::RenderingTeardown => {
                     lifecycle.set(Lifecycle::Stopped);
-                    queue_animating(&ui_weak, false);
+                    frame_requested.set(false);
                 }
                 _ => {}
             }
@@ -98,42 +122,6 @@ pub fn init(
                 let size =
                     maplibre_native::Size { width: size.width as u32, height: size.height as u32 };
                 map.upgrade().unwrap().borrow_mut().set_map_size(size);
-            }
-        }
-    });
-
-    ui.global::<MapAdapter>().on_tick_map_loop({
-        let map = Rc::downgrade(map);
-        let ui_handle = ui.as_weak();
-        let styled = Cell::new(false);
-        let lifecycle = lifecycle.clone();
-        move || {
-            if lifecycle.get() != Lifecycle::Running {
-                // Stop the frame clock if a stale wake arrives before init or after stop.
-                queue_animating(&ui_handle, false);
-                return;
-            }
-
-            let map = map.upgrade().unwrap();
-            let mut map = map.borrow_mut();
-            map.renderer().render_once();
-
-            if let Some(error) = map.style_loading_error() {
-                eprintln!("Failed to load map: {error}");
-                lifecycle.set(Lifecycle::Stopped);
-                queue_animating(&ui_handle, false);
-                return;
-            }
-
-            if map.style_loaded() && !styled.get() {
-                style(&mut map);
-                styled.set(true);
-            }
-
-            if let Some(image) = map.renderer().take_texture()
-                && let Ok(image) = image.try_into()
-            {
-                ui_handle.upgrade().unwrap().global::<MapAdapter>().set_map_texture(image);
             }
         }
     });
@@ -183,30 +171,6 @@ pub fn init(
             let pos = ScreenCoordinate { x: x.into(), y: y.into() };
             let scale = STEP.powf(f64::from(delta) / DELTA_PER_STEP);
             map.upgrade().unwrap().borrow_mut().renderer().scale_by(scale, pos);
-        }
-    });
-
-    ui.global::<MapAdapter>().on_bearing_changed({
-        let map = Rc::downgrade(map);
-        let lifecycle = lifecycle.clone();
-        move |delta: f32| {
-            if lifecycle.get() != Lifecycle::Running {
-                return;
-            }
-            // MapLibre's rotateBy API expects a gesture from one pointer position to another.
-            // Control+wheel provides only a scalar delta, so convert it into a small synthetic drag.
-            map.upgrade().unwrap().borrow_mut().rotate_by(delta);
-        }
-    });
-
-    ui.global::<MapAdapter>().on_pitch_changed({
-        let map = Rc::downgrade(map);
-        let lifecycle = lifecycle.clone();
-        move |delta: f32| {
-            if lifecycle.get() != Lifecycle::Running {
-                return;
-            }
-            map.upgrade().unwrap().borrow_mut().renderer().pitch_by(delta.into());
         }
     });
 

--- a/examples/slint/src/maplibre.rs
+++ b/examples/slint/src/maplibre.rs
@@ -4,45 +4,89 @@ use maplibre_native::{
     CircleLayer, Color, FillLayer, GeoJson, GeoJsonSource, LineLayer, ScreenCoordinate,
     SymbolAnchor, SymbolLayer,
 };
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::path::Path;
 use std::rc::Rc;
 mod headless;
 pub use headless::{MapLibre, create_map};
 use slint::ComponentHandle;
 
-pub fn init(ui: &MainWindow, map: &Rc<RefCell<MapLibre>>) {
-    loop {
-        let mut borrow = map.borrow_mut();
-        borrow.renderer().render_once();
+/// Graphics context lifecycle.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Lifecycle {
+    Uninitialized,
+    Running,
+    Stopped,
+}
 
-        if let Some(error) = borrow.style_loading_error() {
-            panic!("Failed to load map: {}", error);
-        }
+fn queue_animating(ui: &slint::Weak<MainWindow>, animating: bool) {
+    let _ = ui.upgrade_in_event_loop(move |ui| {
+        ui.global::<MapAdapter>().set_animating(animating);
+    });
+}
 
-        if borrow.style_loaded() {
-            drop(borrow);
-            style(map);
-            break;
-        }
-    }
+pub fn init(
+    ui: &MainWindow,
+    map: &Rc<RefCell<MapLibre>>,
+    style_url: impl Into<String>,
+) -> Option<slint::Timer> {
+    let style_url = style_url.into();
+    let lifecycle = Rc::new(Cell::new(Lifecycle::Uninitialized));
 
     ui.window()
         .set_rendering_notifier({
             let map = Rc::downgrade(map);
-            move |state, graphics_api| {
-                if matches!(state, slint::RenderingState::RenderingSetup) {
-                    let slint::GraphicsAPI::WGPU29 { instance: _instance, device, queue, .. } =
-                        graphics_api
-                    else {
+            let lifecycle = lifecycle.clone();
+            let ui_weak = ui.as_weak();
+            move |state, graphics_api| match state {
+                slint::RenderingState::RenderingSetup => {
+                    if lifecycle.get() != Lifecycle::Uninitialized {
+                        eprintln!("graphics re-setup after teardown is unsupported");
+                        return;
+                    }
+                    let slint::GraphicsAPI::WGPU29 { device, queue, .. } = graphics_api else {
                         return;
                     };
-                    map.upgrade()
-                        .unwrap()
-                        .borrow_mut()
-                        .renderer()
-                        .set_device_queue(device.clone(), queue.clone());
+                    let ui = ui_weak.upgrade().unwrap();
+                    let map = map.upgrade().unwrap();
+                    let mut map = map.borrow_mut();
+
+                    // Build the renderer now that the pixel ratio (scale factor) is known.
+                    map.build_renderer(ui.window().scale_factor());
+                    map.renderer().set_device_queue(device.clone(), queue.clone());
+
+                    // MapLibre asks for a frame (input, transitions, async loads);
+                    // going idle stops the clock again.
+                    map.renderer().set_render_requested_callback({
+                        let lifecycle = lifecycle.clone();
+                        let ui = ui.as_weak();
+                        move || {
+                            if lifecycle.get() == Lifecycle::Running {
+                                queue_animating(&ui, true);
+                            }
+                        }
+                    });
+                    map.renderer().map_observer().set_did_become_idle_callback({
+                        let lifecycle = lifecycle.clone();
+                        let ui = ui.as_weak();
+                        move || {
+                            if lifecycle.get() == Lifecycle::Running {
+                                queue_animating(&ui, false);
+                            }
+                        }
+                    });
+
+                    map.renderer().load_style_from_url(
+                        &style_url.parse().expect("style URL should be valid"),
+                    );
+                    lifecycle.set(Lifecycle::Running);
+                    queue_animating(&ui_weak, true);
                 }
+                slint::RenderingState::RenderingTeardown => {
+                    lifecycle.set(Lifecycle::Stopped);
+                    queue_animating(&ui_weak, false);
+                }
+                _ => {}
             }
         })
         .unwrap();
@@ -61,12 +105,32 @@ pub fn init(ui: &MainWindow, map: &Rc<RefCell<MapLibre>>) {
     ui.global::<MapAdapter>().on_tick_map_loop({
         let map = Rc::downgrade(map);
         let ui_handle = ui.as_weak();
+        let styled = Cell::new(false);
+        let lifecycle = lifecycle.clone();
         move || {
+            if lifecycle.get() != Lifecycle::Running {
+                // Stop the frame clock if a stale wake arrives before init or after stop.
+                queue_animating(&ui_handle, false);
+                return;
+            }
+
             let map = map.upgrade().unwrap();
             let mut map = map.borrow_mut();
             map.renderer().render_once();
-            if map.updated()
-                && let Some(image) = map.renderer().take_texture()
+
+            if let Some(error) = map.style_loading_error() {
+                eprintln!("Failed to load map: {error}");
+                lifecycle.set(Lifecycle::Stopped);
+                queue_animating(&ui_handle, false);
+                return;
+            }
+
+            if map.style_loaded() && !styled.get() {
+                style(&mut map);
+                styled.set(true);
+            }
+
+            if let Some(image) = map.renderer().take_texture()
                 && let Ok(image) = image.try_into()
             {
                 ui_handle.upgrade().unwrap().global::<MapAdapter>().set_map_texture(image);
@@ -86,12 +150,19 @@ pub fn init(ui: &MainWindow, map: &Rc<RefCell<MapLibre>>) {
 
     ui.global::<MapAdapter>().on_mouse_move({
         let map = Rc::downgrade(map);
-        move |x: f32, y: f32, _z: bool| {
+        move |x: f32, y: f32, ctrl: bool| {
             let p = ScreenCoordinate { x: x.into(), y: y.into() };
             let map = map.upgrade().unwrap();
             let mut map = map.borrow_mut();
             let delta = p - map.position();
-            map.renderer().move_by(delta);
+            if ctrl {
+                const ROTATE_DEG_PER_PX: f64 = 0.5;
+                const PITCH_DEG_PER_PX: f64 = 0.5;
+                map.rotate_by((-delta.x * ROTATE_DEG_PER_PX) as f32);
+                map.renderer().pitch_by(delta.y * PITCH_DEG_PER_PX);
+            } else {
+                map.renderer().move_by(delta);
+            }
             map.set_position(p);
         }
     });
@@ -100,8 +171,9 @@ pub fn init(ui: &MainWindow, map: &Rc<RefCell<MapLibre>>) {
         let map = Rc::downgrade(map);
         move |x: f32, y: f32, delta: f32| {
             const STEP: f64 = 1.2;
+            const DELTA_PER_STEP: f64 = 60.0;
             let pos = ScreenCoordinate { x: x.into(), y: y.into() };
-            let scale = if delta > 0. { STEP } else { 1.0 / STEP };
+            let scale = STEP.powf(f64::from(delta) / DELTA_PER_STEP);
             map.upgrade().unwrap().borrow_mut().renderer().scale_by(scale, pos);
         }
     });
@@ -121,12 +193,25 @@ pub fn init(ui: &MainWindow, map: &Rc<RefCell<MapLibre>>) {
             map.upgrade().unwrap().borrow_mut().renderer().pitch_by(delta.into());
         }
     });
+
+    pump_run_loop_timer()
+}
+
+fn pump_run_loop_timer() -> Option<slint::Timer> {
+    // Slint drives Core Foundation, but libuv must be pumped explicitly.
+    if !maplibre_native::RunLoopHandle::uses_libuv() {
+        return None;
+    }
+    let timer = slint::Timer::default();
+    timer.start(slint::TimerMode::Repeated, std::time::Duration::from_millis(16), || {
+        maplibre_native::RunLoopHandle::current().tick();
+    });
+    Some(timer)
 }
 
 // Style the map and add a marker
-fn style(map: &Rc<RefCell<MapLibre>>) {
-    let mut map_borrow = map.borrow_mut();
-    let mut style = map_borrow.renderer().style();
+fn style(map: &mut MapLibre) {
+    let mut style = map.renderer().style();
 
     let image = ImageReader::open(
         Path::new(env!("CARGO_MANIFEST_DIR")).join("ui").join("icons").join("Marker.png"),

--- a/examples/slint/src/maplibre/headless.rs
+++ b/examples/slint/src/maplibre/headless.rs
@@ -13,40 +13,85 @@ use maplibre_native::{
 struct Flags {
     loading_style_error: Option<MapLoadError>,
     style_loaded: bool,
-    map_idle: bool,
-    frame_updated: bool,
 }
 
 pub struct MapLibre {
     flags: Rc<RefCell<Flags>>,
-    renderer: ImageRenderer<Continuous>,
+    renderer: Option<ImageRenderer<Continuous>>,
     last_pos: ScreenCoordinate,
     map_size: Size,
 }
 
 impl MapLibre {
-    pub fn new(renderer: ImageRenderer<Continuous>, map_size: Size) -> Self {
-        Self { renderer, flags: Rc::default(), last_pos: ScreenCoordinate::default(), map_size }
+    pub fn new(map_size: Size) -> Self {
+        Self {
+            renderer: None,
+            flags: Rc::default(),
+            last_pos: ScreenCoordinate::default(),
+            map_size,
+        }
     }
 
-    #[allow(dead_code)]
+    /// Builds the renderer once the host's pixel ratio (scale factor) is known.
+    pub fn build_renderer(&mut self, pixel_ratio: f32) {
+        let resource_options = ResourceOptions::default()
+            .with_tile_server_options(&TileServerOptions::default())
+            // .with_api_key(api_key)
+            .with_cache_path(
+                Path::new(env!("CARGO_MANIFEST_DIR")).join("maplibre_database.sqlite"),
+            );
+
+        let mut builder = ImageRendererBuilder::new().with_pixel_ratio(pixel_ratio);
+        if self.map_size.width > 0 && self.map_size.height > 0 {
+            builder = builder.with_size(
+                NonZeroU32::new(self.map_size.width).unwrap(),
+                NonZeroU32::new(self.map_size.height).unwrap(),
+            );
+        }
+        let mut renderer =
+            builder.with_resource_options(resource_options).build_continuous_renderer();
+        renderer.update_camera(
+            &CameraUpdate::new()
+                .center(LatLng { lat: 0.0, lng: 0.0 })
+                .zoom(0.0)
+                .bearing(0.0)
+                .pitch(0.0),
+        );
+
+        let observer = renderer.map_observer();
+        observer.set_did_finish_loading_style_callback({
+            let flags = Rc::downgrade(&self.flags);
+            move || {
+                if let Some(flags) = flags.upgrade() {
+                    flags.borrow_mut().style_loaded = true;
+                }
+            }
+        });
+        observer.set_did_fail_loading_map_callback({
+            let flags = Rc::downgrade(&self.flags);
+            move |error| {
+                println!("Failed to load map: {}", error.message);
+                if let Some(flags) = flags.upgrade() {
+                    let mut flags = flags.borrow_mut();
+                    flags.style_loaded = false;
+                    flags.loading_style_error = Some(error);
+                }
+            }
+        });
+
+        self.renderer = Some(renderer);
+    }
+
     pub fn style_loaded(&self) -> bool {
         self.flags.borrow().style_loaded
     }
 
-    #[allow(dead_code)]
     pub fn style_loading_error(&self) -> Option<MapLoadError> {
         self.flags.borrow().loading_style_error.clone()
     }
 
-    pub fn updated(&mut self) -> bool {
-        let updated = self.flags.borrow().frame_updated;
-        self.flags.borrow_mut().frame_updated = false;
-        updated
-    }
-
-    pub fn renderer(&mut self) -> &mut ImageRenderer<Continuous> {
-        &mut self.renderer
+    pub(super) fn renderer(&mut self) -> &mut ImageRenderer<Continuous> {
+        self.renderer.as_mut().expect("renderer is built during RenderingSetup")
     }
 
     pub fn set_position(&mut self, pos: ScreenCoordinate) {
@@ -59,7 +104,9 @@ impl MapLibre {
 
     pub fn set_map_size(&mut self, size: Size) {
         self.map_size = size;
-        self.renderer.set_map_size(size);
+        if let Some(renderer) = self.renderer.as_mut() {
+            renderer.set_map_size(size);
+        }
     }
 
     // Inverse the map rotation logic from MapLibre's `Map::rotateBy` to convert a control+wheel delta into a synthetic drag gesture.
@@ -89,92 +136,12 @@ impl MapLibre {
             y: center.y + relative.x * angle.sin() + relative.y * angle.cos(),
         };
 
-        self.renderer.rotate_by(first, second);
+        self.renderer().rotate_by(first, second);
     }
 }
 
 pub fn create_map(size: Size) -> Rc<RefCell<MapLibre>> {
-    let resource_options = ResourceOptions::default()
-        .with_tile_server_options(&TileServerOptions::default())
-        // .with_api_key(api_key)
-        .with_cache_path(Path::new(env!("CARGO_MANIFEST_DIR")).join("maplibre_database.sqlite"));
-
-    let mut renderer = ImageRendererBuilder::new();
-    let mut map_size = Size { width: 0, height: 0 };
-    if size.width > 0 && size.height > 0 {
-        map_size = size;
-        renderer = renderer.with_size(
-            NonZeroU32::new(size.width as u32).unwrap(),
-            NonZeroU32::new(size.height as u32).unwrap(),
-        );
-    }
-    let mut renderer = renderer
-        .with_pixel_ratio(1.0)
-        .with_resource_options(resource_options)
-        .build_continuous_renderer();
-
-    // setting the camera is important, otherwise maplibre does nothing
-    // (no logs are coming and no map gets generated).
-    renderer.update_camera(
-        &CameraUpdate::new()
-            .center(LatLng { lat: 0.0, lng: 0.0 })
-            .zoom(0.0)
-            .bearing(0.0)
-            .pitch(0.0),
-    );
-
-    let map = Rc::new(RefCell::new(MapLibre::new(renderer, map_size)));
-
-    let map_observer = map.borrow_mut().renderer().map_observer();
-    map_observer.set_did_become_idle_callback({
-        let flags = Rc::downgrade(&map.borrow().flags);
-        move || {
-            flags.upgrade().inspect(|v| {
-                v.borrow_mut().map_idle = true;
-            });
-        }
-    });
-    map_observer.set_will_start_loading_map_callback({
-        let flags = Rc::downgrade(&map.borrow().flags);
-        move || {
-            println!("set_on_will_start_loading_map_callback");
-            flags.upgrade().inspect(|v| {
-                v.borrow_mut().map_idle = false;
-                v.borrow_mut().style_loaded = false;
-            });
-        }
-    });
-    map_observer.set_did_finish_loading_style_callback({
-        let flags = Rc::downgrade(&map.borrow().flags);
-        move || {
-            println!("set_on_did_finish_loading_style_callback");
-            flags.upgrade().inspect(|v| {
-                v.borrow_mut().style_loaded = true;
-            });
-        }
-    });
-    map_observer.set_did_fail_loading_map_callback({
-        let flags = Rc::downgrade(&map.borrow().flags);
-        move |error| {
-            println!("Failed to load map: {}", error.message);
-            flags.upgrade().inspect(|v| {
-                let mut borrow = v.borrow_mut();
-                borrow.style_loaded = false;
-                borrow.loading_style_error = Some(error);
-            });
-        }
-    });
-    map_observer.set_camera_changed_callback(|_mode| {});
-    map_observer.set_finish_rendering_frame_callback({
-        let flags = Rc::downgrade(&map.borrow().flags);
-        move |needs_repaint: bool, placement_changed: bool| {
-            if needs_repaint || placement_changed {
-                flags.upgrade().inspect(|v| {
-                    v.borrow_mut().frame_updated = true;
-                });
-            }
-        }
-    });
-
-    map
+    let map_size =
+        if size.width > 0 && size.height > 0 { size } else { Size { width: 0, height: 0 } };
+    Rc::new(RefCell::new(MapLibre::new(map_size)))
 }

--- a/examples/slint/src/maplibre/headless.rs
+++ b/examples/slint/src/maplibre/headless.rs
@@ -141,7 +141,5 @@ impl MapLibre {
 }
 
 pub fn create_map(size: Size) -> Rc<RefCell<MapLibre>> {
-    let map_size =
-        if size.width > 0 && size.height > 0 { size } else { Size { width: 0, height: 0 } };
-    Rc::new(RefCell::new(MapLibre::new(map_size)))
+    Rc::new(RefCell::new(MapLibre::new(size)))
 }

--- a/examples/slint/ui/main.slint
+++ b/examples/slint/ui/main.slint
@@ -10,6 +10,7 @@ export struct Size {
 // TODO: make this not global, because then it can be used only for one instance!
 export global MapAdapter {
     in-out property <image> map_texture;
+    in-out property <bool> animating;
     callback tick_map_loop();
     callback mouse_press(x: float, y: float);
     callback mouse_release(x: float, y: float);
@@ -33,10 +34,9 @@ component MapWidget {
         map-size-changed(map-size);
     }
 
-    Timer {
-        interval: 16ms;
-        running: true;
-        triggered => {
+    property <duration> frame-tick: MapAdapter.animating ? animation-tick() : 0ms;
+    changed frame-tick => {
+        if (MapAdapter.animating) {
             MapAdapter.tick_map_loop();
         }
     }
@@ -46,7 +46,7 @@ component MapWidget {
 
         map := Image {
             source: MapAdapter.map_texture;
-            image-fit: preserve; // Otherwise the mouse move is not correctly
+            image-fit: fill;
             vertical-alignment: center;
             horizontal-alignment: center;
 
@@ -64,21 +64,13 @@ component MapWidget {
                     } else if (e.kind == PointerEventKind.up) {
                         MapAdapter.mouse_release(self.mouse-x / 1px, self.mouse-y / 1px);
                     } else if (e.kind == PointerEventKind.move && self.pressed) {
-                        MapAdapter.mouse_move(self.mouse-x / 1px, self.mouse-y / 1px, true);
+                        MapAdapter.mouse_move(self.mouse-x / 1px, self.mouse-y / 1px, e.modifiers.control);
                     }
                 }
 
                 // Mouse-wheel / trackpad scroll to zoom
                 scroll-event(event) => {
-                    if event.modifiers.shift {
-                        MapAdapter.pitch_changed(event.delta_y / 10px);
-                    } else if event.modifiers.control {
-                        MapAdapter.bearing_changed(event.delta_y / 10px);
-                    } else {
-                        MapAdapter.wheel_zoom(self.mouse-x / 1px,
-                                        self.mouse-y / 1px,
-                                        event.delta_y / 1px);
-                    }
+                    MapAdapter.wheel_zoom(self.mouse-x / 1px, self.mouse-y / 1px, event.delta_y / 1px);
                     return accept;
                 }
             }

--- a/examples/slint/ui/main.slint
+++ b/examples/slint/ui/main.slint
@@ -1,6 +1,3 @@
-import { Button, VerticalBox, ComboBox, HorizontalBox, Slider } from "std-widgets.slint";
-
-
 // Define a struct to hold window size
 export struct Size {
     width: length,
@@ -10,17 +7,9 @@ export struct Size {
 // TODO: make this not global, because then it can be used only for one instance!
 export global MapAdapter {
     in-out property <image> map_texture;
-    in-out property <bool> animating;
-    callback tick_map_loop();
     callback mouse_press(x: float, y: float);
-    callback mouse_release(x: float, y: float);
     callback mouse_move(x: float, y: float, bool);
-    callback style_changed(style: string);
-    callback double_click_with_shift(x: float, y: float, shift_pressed: bool);
     callback wheel_zoom(x: float, y: float, zoom_delta: float); // Positive delta_y: zoom out; Negative: zoom in
-    callback fly_to(location: string);
-    callback pitch_changed(float);
-    callback bearing_changed(float);
 }
 
 component MapWidget {
@@ -34,13 +23,6 @@ component MapWidget {
         map-size-changed(map-size);
     }
 
-    property <duration> frame-tick: MapAdapter.animating ? animation-tick() : 0ms;
-    changed frame-tick => {
-        if (MapAdapter.animating) {
-            MapAdapter.tick_map_loop();
-        }
-    }
-
     VerticalLayout {
         spacing: 0px;
 
@@ -51,18 +33,11 @@ component MapWidget {
             horizontal-alignment: center;
 
             touch := TouchArea {
-                // Track last seen Shift modifier state from pointer events
-                property <bool> last-shift: false;
                 mouse-cursor: self.pressed ? grabbing : grab;
 
-                // Handle all pointer events properly
                 pointer-event(e) => {
-                    self.last-shift = e.modifiers.shift;
-
                     if (e.kind == PointerEventKind.down) {
                         MapAdapter.mouse_press(self.mouse-x / 1px, self.mouse-y / 1px);
-                    } else if (e.kind == PointerEventKind.up) {
-                        MapAdapter.mouse_release(self.mouse-x / 1px, self.mouse-y / 1px);
                     } else if (e.kind == PointerEventKind.move && self.pressed) {
                         MapAdapter.mouse_move(self.mouse-x / 1px, self.mouse-y / 1px, e.modifiers.control);
                     }

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -3,8 +3,8 @@ use std::ops::Sub;
 
 use crate::renderer::callbacks::{
     camera_did_change_callback, failing_loading_map_callback, finish_rendering_frame_callback,
-    void_callback, CameraDidChangeCallback, FailingLoadingMapCallback,
-    FinishRenderingFrameCallback, VoidCallback,
+    render_requested_callback, void_callback, CameraDidChangeCallback, FailingLoadingMapCallback,
+    FinishRenderingFrameCallback, RenderRequestedCallback, VoidCallback,
 };
 use crate::renderer::file_source::{BoxedFileSource, RequestHandleFfi};
 
@@ -1130,6 +1130,8 @@ pub mod ffi {
         /// In-flight render request.
         type RenderRequest;
 
+        /// Whether MapLibre Native uses the libuv run-loop backend.
+        fn run_loop_uses_libuv() -> bool;
         /// Ticks the current thread's MapLibre Native run loop once (non-blocking).
         fn currentThreadRunLoopTick();
         /// Blocks the calling thread, advancing the run loop until it is woken by
@@ -1157,6 +1159,11 @@ pub mod ffi {
         fn bufferLength(self: &BridgeImage) -> usize;
         /// Renders a single frame.
         fn render_once(self: Pin<&mut MapRenderer>);
+        /// Sets the callback invoked when MapLibre Native requests a frame.
+        fn setRenderRequestedCallback(
+            self: Pin<&mut MapRenderer>,
+            callback: Box<RenderRequestedCallback>,
+        );
         /// Submits a render request without waiting for completion.
         fn submitRender(self: Pin<&mut MapRenderer>) -> UniquePtr<RenderRequest>;
         /// Calculates camera options that fit geographic bounds.
@@ -1265,6 +1272,10 @@ pub mod ffi {
 
     // Declarations for C++ with implementations in Rust
     extern "Rust" {
+        type RenderRequestedCallback;
+
+        fn render_requested_callback(callback: &RenderRequestedCallback);
+
         /// Bridge logging from C++ to Rust log crate
         fn log_from_cpp(severity: EventSeverity, event: Event, code: i64, message: &str);
     }

--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -50,6 +50,8 @@ namespace bridge {
 
 struct Texture;
 struct TextureView;
+struct RenderRequestedCallback;
+void render_requested_callback(const RenderRequestedCallback& callback) noexcept;
 
 constexpr size_t BYTES_PER_PIXEL = 4; // rgba
 
@@ -106,6 +108,14 @@ inline void currentThreadRunLoopStop() {
 #endif
 }
 
+inline bool run_loop_uses_libuv() noexcept {
+#if defined(__APPLE__) && !defined(MLN_DARWIN_USE_LIBUV)
+    return false;
+#else
+    return true;
+#endif
+}
+
 inline std::unique_ptr<std::string> encodeImage(mbgl::PremultipliedImage image) {
     auto unpremultipliedImage = mbgl::util::unpremultiply(std::move(image));
 
@@ -124,6 +134,31 @@ inline std::unique_ptr<std::string> encodeImage(mbgl::PremultipliedImage image) 
     return std::make_unique<std::string>(std::move(data));
 }
 
+class HostFrontend final : public mbgl::HeadlessFrontend {
+public:
+    HostFrontend(mbgl::Size size, float pixelRatio, bool invalidateOnUpdate)
+        : mbgl::HeadlessFrontend(size,
+                                 pixelRatio,
+                                 mbgl::gfx::HeadlessBackend::SwapBehaviour::NoFlush,
+                                 mbgl::gfx::ContextMode::Unique,
+                                 std::nullopt,
+                                 invalidateOnUpdate) {}
+
+    void setRenderRequestedCallback(rust::Box<RenderRequestedCallback> callback) {
+        renderRequestedCallback = std::move(callback);
+    }
+
+    void update(std::shared_ptr<mbgl::UpdateParameters> updateParameters) override {
+        mbgl::HeadlessFrontend::update(std::move(updateParameters));
+        if (renderRequestedCallback) {
+            render_requested_callback(*(*renderRequestedCallback));
+        }
+    }
+
+private:
+    std::optional<rust::Box<RenderRequestedCallback>> renderRequestedCallback;
+};
+
 class MapRenderer {
 public:
     explicit MapRenderer(mbgl::MapMode mapMode,
@@ -132,7 +167,9 @@ public:
                          const mbgl::ResourceOptions& resourceOptions)
         : mapObserverInstance(std::make_shared<MapObserver>()) {
         bindThreadRunLoop();
-        frontend = std::make_unique<mbgl::HeadlessFrontend>(size, pixelRatio);
+        // Continuous renderers are host-driven.
+        bool invalidateOnUpdate = mapMode != mbgl::MapMode::Continuous;
+        frontend = std::make_unique<HostFrontend>(size, pixelRatio, invalidateOnUpdate);
 
         mbgl::MapOptions mapOptions;
         mapOptions.withMapMode(mapMode).withSize(size).withPixelRatio(pixelRatio);
@@ -213,7 +250,14 @@ public:
     }
 
     void render_once() {
-        frontend->renderOnce(*map);
+#if !defined(__APPLE__) || defined(MLN_DARWIN_USE_LIBUV)
+        currentThreadRunLoopTick();
+#endif
+        frontend->renderFrame();
+    }
+
+    void setRenderRequestedCallback(rust::Box<RenderRequestedCallback> callback) {
+        frontend->setRenderRequestedCallback(std::move(callback));
     }
 
     std::unique_ptr<RenderRequest> submitRender();
@@ -276,7 +320,7 @@ public:
 public:
     // CXX bridge helpers below access these directly. Keep them alive here
     // because the frontend and observer are passed by reference to the map.
-    std::unique_ptr<mbgl::HeadlessFrontend> frontend;
+    std::unique_ptr<HostFrontend> frontend;
     std::shared_ptr<MapObserver> mapObserverInstance;
     std::unique_ptr<mbgl::Map> map;
 };

--- a/src/renderer/builder.rs
+++ b/src/renderer/builder.rs
@@ -99,8 +99,12 @@ impl ImageRendererBuilder {
         ImageRenderer::new(MapMode::Tile, self)
     }
 
-    /// Builds a continuous renderer
-    /// Using the `MapObserver` it is possible to react on signals from the Map
+    /// Builds a continuous renderer.
+    ///
+    /// Frames are host-driven: use [`ImageRenderer::set_render_requested_callback`] to wake the
+    /// host UI's display loop, then call [`ImageRenderer::render_once`] for each scheduled frame.
+    ///
+    /// Use the `MapObserver` to react to signals from the map.
     #[must_use]
     pub fn build_continuous_renderer(self) -> ImageRenderer<Continuous> {
         ImageRenderer::new(MapMode::Continuous, self)

--- a/src/renderer/builder.rs
+++ b/src/renderer/builder.rs
@@ -101,10 +101,17 @@ impl ImageRendererBuilder {
 
     /// Builds a continuous renderer.
     ///
-    /// Frames are host-driven: use [`ImageRenderer::set_render_requested_callback`] to wake the
-    /// host UI's display loop, then call [`ImageRenderer::render_once`] for each scheduled frame.
+    /// Frames are host-driven: use [`ImageRenderer::<Continuous>::set_render_requested_callback`] to wake the
+    /// host UI's display loop, then call [`ImageRenderer::<Continuous>::render_once`] for each scheduled frame.
     ///
     /// Use the `MapObserver` to react to signals from the map.
+    ///
+    /// # Breaking change
+    ///
+    /// This renderer no longer self-invalidates (MapLibre Native used to schedule
+    /// its own renders on update). The signature is unchanged, so existing callers
+    /// keep compiling but stop producing frames until they drive
+    /// [`render_once`](ImageRenderer::<Continuous>::render_once) themselves.
     #[must_use]
     pub fn build_continuous_renderer(self) -> ImageRenderer<Continuous> {
         ImageRenderer::new(MapMode::Continuous, self)

--- a/src/renderer/callbacks.rs
+++ b/src/renderer/callbacks.rs
@@ -35,6 +35,12 @@ pub fn void_callback(callback: &VoidCallback) {
     (callback.0)();
 }
 
+callback!(RenderRequestedCallback, Fn());
+/// Invoke a render-request callback.
+pub fn render_requested_callback(callback: &RenderRequestedCallback) {
+    (callback.0)();
+}
+
 callback!(FinishRenderingFrameCallback, Fn(bool, bool));
 /// `finish_rendering_frame_callback`
 pub fn finish_rendering_frame_callback(

--- a/src/renderer/image_renderer.rs
+++ b/src/renderer/image_renderer.rs
@@ -536,6 +536,19 @@ impl ImagePtr {
 }
 
 impl ImageRenderer<Continuous> {
+    /// Sets the callback invoked when MapLibre Native requests a frame.
+    ///
+    /// The callback should schedule [`render_once`](Self::render_once) on the
+    /// renderer's thread using the host's display loop.
+    pub fn set_render_requested_callback<F>(&mut self, callback: F)
+    where
+        F: Fn() + 'static,
+    {
+        self.instance.pin_mut().setRenderRequestedCallback(Box::new(
+            crate::renderer::callbacks::RenderRequestedCallback::new(callback),
+        ));
+    }
+
     /// Applies a partial camera update immediately.
     ///
     /// See [this graphic](https://en.wikipedia.org/wiki/Degrees_of_freedom_(mechanics)#/media/File:Flight_dynamics_with_text.svg)
@@ -566,7 +579,10 @@ impl ImageRenderer<Continuous> {
         self.instance.pin_mut().rotateBy(&first, &second);
     }
 
-    /// Trigger render loop once (animations)
+    /// Renders the current map state into the texture.
+    ///
+    /// Call this once per frame requested by the host UI for a renderer created with
+    /// [`build_continuous_renderer`](crate::ImageRendererBuilder::build_continuous_renderer).
     pub fn render_once(&mut self) {
         self.instance.pin_mut().render_once();
     }

--- a/src/renderer/image_renderer.rs
+++ b/src/renderer/image_renderer.rs
@@ -583,6 +583,12 @@ impl ImageRenderer<Continuous> {
     ///
     /// Call this once per frame requested by the host UI for a renderer created with
     /// [`build_continuous_renderer`](crate::ImageRendererBuilder::build_continuous_renderer).
+    ///
+    /// It also advances MapLibre Native's run loop once so asynchronous work (style
+    /// and tile loading) can progress — except on macOS/iOS, where the Core
+    /// Foundation run loop is assumed to be driven by the host UI's main loop. A
+    /// continuous renderer on a dedicated Apple thread with no host loop must pump
+    /// it itself (see [`RunLoopHandle`]).
     pub fn render_once(&mut self) {
         self.instance.pin_mut().render_once();
     }

--- a/src/renderer/run_loop.rs
+++ b/src/renderer/run_loop.rs
@@ -21,6 +21,12 @@ impl RunLoopHandle {
         Self { _not_send: PhantomData }
     }
 
+    /// Whether MapLibre Native uses the libuv run-loop backend.
+    #[must_use]
+    pub fn uses_libuv() -> bool {
+        ffi::run_loop_uses_libuv()
+    }
+
     /// Ticks the current thread's run loop once (non-blocking).
     #[allow(clippy::unused_self, reason = "method syntax ties ticking to a run-loop handle")]
     pub fn tick(&self) {

--- a/tests/image_renderer.rs
+++ b/tests/image_renderer.rs
@@ -8,7 +8,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use maplibre_native::{
-    CameraUpdate, Color, EdgeInsets, FillLayer, GeoJson, GeoJsonSource, ImageRenderer,
+    CameraUpdate, Color, Continuous, EdgeInsets, FillLayer, GeoJson, GeoJsonSource, ImageRenderer,
     ImageRendererBuilder, LatLng, LatLngBounds, MapLoadErrorKind, RunLoopHandle, Static, Tile,
 };
 
@@ -47,6 +47,22 @@ fn tick_until_ready(mut ready: impl FnMut() -> bool) {
         assert!(Instant::now() < deadline, "request did not complete within {RENDER_TIMEOUT:?}");
         run_loop.tick();
     }
+}
+
+#[test]
+fn continuous_renderer_requests_frame_after_update() {
+    let mut renderer: ImageRenderer<Continuous> = ImageRendererBuilder::new()
+        .with_size(NonZeroU32::new(128).unwrap(), NonZeroU32::new(128).unwrap())
+        .with_pixel_ratio(1.0)
+        .build_continuous_renderer();
+    let requested = Rc::new(Cell::new(false));
+    renderer.set_render_requested_callback({
+        let requested = requested.clone();
+        move || requested.set(true)
+    });
+
+    renderer.update_camera(&CameraUpdate::new().zoom(1.0));
+    tick_until_ready(|| requested.get());
 }
 
 #[test]


### PR DESCRIPTION
Relates to #269.

The Slint example was extremely slow on macOS because MLN and Slint share the same Apple Core Foundation event loop. Using MLN's `invalidateOnUpdate` created a feedback loop where updates kept scheduling renders, starving Slint's UI work.

This PR makes rendering host-driven: MLN requests a frame, and Slint renders it on the next display tick. Rendering stops when MLN becomes idle, which may be useful for other platforms. (The self-invalidating mode could be restored later if needed.)

fixed version:

https://github.com/user-attachments/assets/e0d4f785-7948-4e3a-9eaa-5b457d99f8d8

@Murmele, could you check whether this works on Linux?