### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.9.0...v0.9.1) - 2026-08-28
+
+### Fixed
+
+- *(file_source)* return cached body for network 304s ([#280](https://github.com/maplibre/maplibre-native-rs/pull/280))
+- *(renderer)* apply the maximum cache size to the ambient cache ([#277](https://github.com/maplibre/maplibre-native-rs/pull/277))
+
+### Other
+
+- *(deps)* bump taiki-e/install-action from 2.85.2 to 2.85.5 in the all-actions-version-updates group ([#276](https://github.com/maplibre/maplibre-native-rs/pull/276))
+- run the test suite under AddressSanitizer and LeakSanitizer ([#275](https://github.com/maplibre/maplibre-native-rs/pull/275))
+- *(deps)* bump the all-actions-version-updates group with 2 updates ([#273](https://github.com/maplibre/maplibre-native-rs/pull/273))
+
 ## [0.9.0](https://github.com/maplibre/maplibre-native-rs/compare/v0.8.7...v0.9.0) - 2026-07-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maplibre_native"
-version = "0.9.0"
+version = "0.9.1"
 description = "Rust bindings to the MapLibre Native map rendering engine"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>", "MapLibre contributors"]
 repository = "https://github.com/maplibre/maplibre-native-rs"
@@ -107,7 +107,7 @@ geojson = "1.0.0"
 image = "0.25"
 insta = "1.43"
 log = "0.4"
-maplibre_native = { path = ".", version = "0.9.0" }
+maplibre_native = { path = ".", version = "0.9.1" }
 serde_json = "1.0"
 tar = "0.4.44"
 thiserror = "2.0.16"

--- a/webgpu-shim/CHANGELOG.md
+++ b/webgpu-shim/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/maplibre/maplibre-native-rs/compare/webgpu-shim-v0.1.1...webgpu-shim-v0.1.2) - 2026-08-28
+
+### Fixed
+
+- *(file_source)* return cached body for network 304s ([#280](https://github.com/maplibre/maplibre-native-rs/pull/280))
+
 ## 0.1.1 - 2026-06-19
 
 ### Fixed

--- a/webgpu-shim/Cargo.toml
+++ b/webgpu-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webgpu-shim"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Webgpu shim based on wgpu"
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `webgpu-shim`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `maplibre_native`: 0.9.0 -> 0.9.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `webgpu-shim`

<blockquote>

## [0.1.2](https://github.com/maplibre/maplibre-native-rs/compare/webgpu-shim-v0.1.1...webgpu-shim-v0.1.2) - 2026-08-28

### Fixed

- *(file_source)* return cached body for network 304s ([#280](https://github.com/maplibre/maplibre-native-rs/pull/280))
</blockquote>

## `maplibre_native`

<blockquote>

## [0.9.1](https://github.com/maplibre/maplibre-native-rs/compare/v0.9.0...v0.9.1) - 2026-08-28

### Fixed

- *(file_source)* return cached body for network 304s ([#280](https://github.com/maplibre/maplibre-native-rs/pull/280))
- *(renderer)* apply the maximum cache size to the ambient cache ([#277](https://github.com/maplibre/maplibre-native-rs/pull/277))

### Other

- *(deps)* bump taiki-e/install-action from 2.85.2 to 2.85.5 in the all-actions-version-updates group ([#276](https://github.com/maplibre/maplibre-native-rs/pull/276))
- run the test suite under AddressSanitizer and LeakSanitizer ([#275](https://github.com/maplibre/maplibre-native-rs/pull/275))
- *(deps)* bump the all-actions-version-updates group with 2 updates ([#273](https://github.com/maplibre/maplibre-native-rs/pull/273))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).