### PR TITLE
fix(renderer): apply the maximum cache size to the ambient cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "sync", "rt-multi-thread"] }
 
 [[test]]
+name = "ambient_cache"
+required-features = ["tokio"]
+
+[[test]]
 name = "file_source_tokio"
 required-features = ["tokio"]
 

--- a/build.rs
+++ b/build.rs
@@ -311,6 +311,7 @@ fn resolve_mln_core() -> (PathBuf, Vec<PathBuf>) {
         deps.join("geometry.hpp").join("include"),
         deps.join("geojson.hpp").join("include"),
         deps.join("variant").join("include"),
+        extracted_path.join("vendor").join("expected-lite").join("include"),
         extracted_path.join("include"),
     ];
     (library_file, include_dirs)

--- a/src/cpp/map_renderer.h
+++ b/src/cpp/map_renderer.h
@@ -16,6 +16,7 @@
 #include <mbgl/util/premultiply.hpp>
 #include <mbgl/util/tile_server_options.hpp>
 #include <mbgl/util/size.hpp>
+#include <mbgl/storage/file_source.hpp>
 #include <mbgl/storage/resource_options.hpp>
 
 #if defined(MLN_WEBGPU_IMPL_FFI)
@@ -34,6 +35,7 @@
 #include "rust/cxx.h"
 #include "rust_log_observer.h"
 #include "map_observer.h"
+#include "resource_options.h"
 #include "sources/sources.h"
 
 #if (!defined(__APPLE__) || defined(MLN_DARWIN_USE_LIBUV)) && __has_include(<uv.h>)
@@ -177,6 +179,7 @@ public:
         // Set up logging observer for Rust bridge
         auto logObserver = std::make_unique<mln::bridge::RustLogObserver>();
         mbgl::Log::setObserver(std::move(logObserver));
+        databaseFileSource = resource_options::applyMaximumAmbientCacheSize(resourceOptions);
         map = std::make_unique<mbgl::Map>(*frontend, *mapObserverInstance, mapOptions, resourceOptions);
     }
 
@@ -322,6 +325,8 @@ public:
     // because the frontend and observer are passed by reference to the map.
     std::unique_ptr<HostFrontend> frontend;
     std::shared_ptr<MapObserver> mapObserverInstance;
+    // Declared before `map` so the map never outlives it.
+    std::shared_ptr<mbgl::FileSource> databaseFileSource;
     std::unique_ptr<mbgl::Map> map;
 };
 

--- a/src/cpp/resource_options.cpp
+++ b/src/cpp/resource_options.cpp
@@ -1,5 +1,9 @@
 #include "rust/cxx.h"
 #include "mbgl/storage/resource_options.hpp"
+#include "mbgl/storage/database_file_source.hpp"
+#include "mbgl/storage/file_source_manager.hpp"
+#include "mbgl/util/logging.hpp"
+#include "rust_file_source.h"
 #include "util.h"
 #include <cassert>
 #include <memory>
@@ -28,6 +32,30 @@ void withMaximumCacheSize(mbgl::ResourceOptions &resource_options, uint64_t max_
 
 void withTileServerOptions(mbgl::ResourceOptions &resource_options, const mbgl::TileServerOptions& tile_server_options) {
     resource_options.withTileServerOptions(tile_server_options);
+}
+
+std::shared_ptr<mbgl::FileSource> applyMaximumAmbientCacheSize(const mbgl::ResourceOptions &resource_options) {
+    if (::mln::bridge::has_rust_database_file_source()) {
+        return nullptr;
+    }
+    auto fileSource =
+        mbgl::FileSourceManager::get()->getFileSource(mbgl::FileSourceType::Database, resource_options);
+    if (!fileSource) {
+        return nullptr;
+    }
+    auto database = std::static_pointer_cast<mbgl::DatabaseFileSource>(fileSource);
+    database->setMaximumAmbientCacheSize(resource_options.maximumCacheSize(), [](std::exception_ptr error) {
+        if (!error) {
+            return;
+        }
+        try {
+            std::rethrow_exception(error);
+        } catch (const std::exception &e) {
+            mbgl::Log::Error(mbgl::Event::Database,
+                             std::string("Failed to set the maximum ambient cache size: ") + e.what());
+        }
+    });
+    return fileSource;
 }
 
 }

--- a/src/cpp/resource_options.h
+++ b/src/cpp/resource_options.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 namespace mbgl {
+    class FileSource;
     class ResourceOptions;
     class TileServerOptions;
 }
@@ -16,5 +17,8 @@ void withCachePath(mbgl::ResourceOptions &resource_options, rust::Slice<const ui
 void withApiKey(mbgl::ResourceOptions &resource_options, rust::Str key);
 void withMaximumCacheSize(mbgl::ResourceOptions &resource_options, uint64_t max_cache_size);
 void withTileServerOptions(mbgl::ResourceOptions &resource_options, const mbgl::TileServerOptions& tile_server_options);
+
+// The caller must keep the returned source alive; the manager holds only a weak reference.
+std::shared_ptr<mbgl::FileSource> applyMaximumAmbientCacheSize(const mbgl::ResourceOptions &resource_options);
 
 }

--- a/src/cpp/rust_file_source.cpp
+++ b/src/cpp/rust_file_source.cpp
@@ -267,7 +267,18 @@ void forward_complete(std::shared_ptr<ForwardState> state) {
     completeForwardState(state);
 }
 
+namespace {
+std::atomic<bool> rust_database_source_registered{false};
+} // namespace
+
+bool has_rust_database_file_source() noexcept {
+    return rust_database_source_registered.load(std::memory_order_acquire);
+}
+
 void register_rust_file_source(FileSourceType source_type, rust::Box<BoxedFileSource> source) {
+    if (source_type == FileSourceType::Database) {
+        rust_database_source_registered.store(true, std::memory_order_release);
+    }
     auto shared_source = std::make_shared<rust::Box<BoxedFileSource>>(std::move(source));
     mbgl::FileSourceManager::get()->registerFileSourceFactory(
         source_type,

--- a/src/cpp/rust_file_source.h
+++ b/src/cpp/rust_file_source.h
@@ -44,6 +44,8 @@ struct ForwardState {
 void register_rust_file_source(FileSourceType source_type,
                                rust::Box<BoxedFileSource> source);
 
+bool has_rust_database_file_source() noexcept;
+
 void responder_complete(std::shared_ptr<RequestState> state,
                         const RawResponse &response);
 

--- a/src/renderer/resource_options.rs
+++ b/src/renderer/resource_options.rs
@@ -51,7 +51,7 @@ impl ResourceOptions {
         self
     }
 
-    /// Set maximum cache size in bytes
+    /// Set the ambient cache maximum size in bytes (0 disables)
     #[must_use]
     pub fn with_maximum_cache_size(mut self, max_cache_size: u64) -> Self {
         resource_options::withMaximumCacheSize(self.ptr.pin_mut(), max_cache_size);

--- a/src/renderer/resource_options.rs
+++ b/src/renderer/resource_options.rs
@@ -52,6 +52,10 @@ impl ResourceOptions {
     }
 
     /// Set the ambient cache maximum size in bytes (0 disables)
+    ///
+    /// Only applies to the default [`Database`](crate::FileSourceType::Database)
+    /// file source. It has no effect once that source is replaced with
+    /// [`register_file_source`](crate::register_file_source).
     #[must_use]
     pub fn with_maximum_cache_size(mut self, max_cache_size: u64) -> Self {
         resource_options::withMaximumCacheSize(self.ptr.pin_mut(), max_cache_size);

--- a/tests/ambient_cache.rs
+++ b/tests/ambient_cache.rs
@@ -1,0 +1,122 @@
+//! Tests that `with_maximum_cache_size` reaches MapLibre Native's ambient cache.
+
+use std::num::NonZeroU32;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime};
+
+use maplibre_native::file_source::Response;
+use maplibre_native::{
+    register_tokio_file_source, CameraUpdate, FileSourceType, ImageRendererBuilder, LatLng,
+    ResourceKind, ResourceOptions, ResourceRequest, Size, TokioFileSource,
+};
+
+const INLINE_STYLE: &str = r#"{
+    "version": 8,
+    "name": "ambient-cache-test",
+    "sources": {},
+    "layers": [
+        { "id": "bg", "type": "background", "paint": { "background-color": "rgb(0, 255, 0)" } }
+    ]
+}"#;
+
+const ETAG: &str = "v1-etag";
+const STYLE_URL: &str = "https://example.invalid/ambient-cache-style.json";
+
+struct NetworkSource {
+    plain_requests: Arc<AtomicUsize>,
+    revalidations: Arc<AtomicUsize>,
+}
+
+impl TokioFileSource for NetworkSource {
+    fn can_request(&self, request: &ResourceRequest) -> bool {
+        request.kind == ResourceKind::Style && request.url.ends_with("/ambient-cache-style.json")
+    }
+
+    async fn request(&self, request: ResourceRequest) -> Response {
+        tokio::task::yield_now().await;
+        if request.prior_etag.as_deref() == Some(ETAG) {
+            self.revalidations.fetch_add(1, Ordering::SeqCst);
+        } else {
+            self.plain_requests.fetch_add(1, Ordering::SeqCst);
+        }
+        Response::data(INLINE_STYLE.as_bytes().to_vec())
+            .with_etag(ETAG)
+            .with_expires(SystemTime::UNIX_EPOCH + Duration::from_secs(4_000_000_000))
+    }
+}
+
+fn render_once(cache_path: PathBuf, maximum_cache_size: u64) {
+    thread::spawn(move || {
+        let options = ResourceOptions::default()
+            .with_cache_path(cache_path)
+            .with_maximum_cache_size(maximum_cache_size);
+        let mut renderer = ImageRendererBuilder::new()
+            .with_size(NonZeroU32::new(64).unwrap(), NonZeroU32::new(64).unwrap())
+            .with_pixel_ratio(1.0)
+            .with_resource_options(options)
+            .build_static_renderer();
+
+        let url: url::Url = STYLE_URL.parse().unwrap();
+        renderer.load_style_from_url(&url);
+        renderer.set_map_size(Size { width: 64, height: 64 });
+
+        renderer
+            .render_static(
+                &CameraUpdate::new()
+                    .center(LatLng { lat: 0.0, lng: 0.0 })
+                    .zoom(0.0)
+                    .bearing(0.0)
+                    .pitch(0.0),
+            )
+            .expect("render should succeed");
+    })
+    .join()
+    .expect("renderer thread should not panic");
+}
+
+fn temp_cache_db(name: &str) -> PathBuf {
+    let path = std::env::temp_dir()
+        .join(format!("mln-ambient-cache-{}-{name}.sqlite", std::process::id()));
+    let _ = std::fs::remove_file(&path);
+    path
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn maximum_cache_size_reaches_the_ambient_cache() {
+    let plain_requests = Arc::new(AtomicUsize::new(0));
+    let revalidations = Arc::new(AtomicUsize::new(0));
+    register_tokio_file_source(
+        FileSourceType::Network,
+        NetworkSource {
+            plain_requests: plain_requests.clone(),
+            revalidations: revalidations.clone(),
+        },
+    );
+
+    let disabled = temp_cache_db("disabled");
+    for _ in 0..3 {
+        render_once(disabled.clone(), 0);
+        thread::sleep(Duration::from_millis(300));
+    }
+    assert_eq!(
+        revalidations.load(Ordering::SeqCst),
+        0,
+        "a disabled ambient cache must never serve a response"
+    );
+    assert_eq!(
+        plain_requests.load(Ordering::SeqCst),
+        3,
+        "every render against a disabled cache should fetch from the network"
+    );
+
+    let enabled = temp_cache_db("enabled");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while revalidations.load(Ordering::SeqCst) == 0 {
+        render_once(enabled.clone(), 10 * 1024 * 1024);
+        assert!(Instant::now() < deadline, "the ambient cache never served the style");
+        thread::sleep(Duration::from_millis(200));
+    }
+}


### PR DESCRIPTION
Closes #248

`with_maximum_cache_size` sets `ResourceOptions::maximumCacheSize`. Nothing in MapLibre Native reads it, so the option did nothing at all. The code search in #248 shows that.

The renderer now applies the size through `DatabaseFileSource::setMaximumAmbientCacheSize` as it builds, before the map first touches the database. The docs on that method ask for it that early. It also holds the database file source for its own lifetime. `FileSourceManager` keeps only weak references, and the setting lives on the instance rather than in the database file.

When a Rust `Database` file source is registered, we skip all of this. That source replaces mbgl's cache and manages its own storage, so casting it to `DatabaseFileSource` would be unsound. The doc comment now says what actually happens.

The test watches through the public API. A hit-counting Rust network source serves a cacheable style against the real SQLite cache. A render served from that cache then shows up as a revalidation request carrying the etag. Size 0 disables the ambient cache per mbgl's own docs, so no request may ever carry one. Give the cache room and a later render has to produce one. On main the test fails: the "disabled" cache stores and serves the style anyway. You can see it as a row in the SQLite file.

Additionally: `resource_options.cpp` now includes `database_file_source.hpp`, which reaches `mbgl/util/expected.hpp` and then `<nonstd/expected.hpp>`. The precompiled header bundle ships `vendor/expected-lite`, but only the source build had it on the include path. Nothing had needed it there yet. One line in `build.rs`.

## Launch Checklist

- [x] Confirm **your changes do not include backports from Mapbox projects** (unless with compliant license) - if you are not sure about this, please ask!
- [x] Briefly describe the changes in this PR.
- [x] Link to related issues.
- [ ] Include before/after visuals or gifs if this PR includes visual changes.
- [x] Write tests for all new functionality.
- [x] Document any changes to public APIs.
- [ ] Post benchmark scores.
- [ ] Add an entry to `CHANGELOG.md` under the `## main` section. (release-plz generates it from the commit titles.)
