### PR TITLE
fix(file_source): return cached body for network 304s

### DIFF
--- a/src/cpp/rust_file_source.cpp
+++ b/src/cpp/rust_file_source.cpp
@@ -146,6 +146,12 @@ void completeState(const std::shared_ptr<RequestState>& state, mbgl::Response re
 
     {
         std::scoped_lock lock(state->response_mutex);
+        // Match OnlineFileSource: priorData means native withheld the cached
+        // representation, so a 304 must deliver it to complete the load.
+        if (response.notModified && state->withheld_prior_body) {
+            response.data = std::move(state->withheld_prior_body);
+            response.notModified = false;
+        }
         state->response.emplace(std::move(response));
     }
     state->dispatch();
@@ -175,9 +181,11 @@ private:
 class RustFileSource final : public mbgl::FileSource {
 public:
     RustFileSource(std::shared_ptr<rust::Box<BoxedFileSource>> source,
+                   bool materializeNotModified,
                    mbgl::ResourceOptions resourceOpts,
                    mbgl::ClientOptions clientOpts)
         : source_(std::move(source)),
+          materializeNotModified_(materializeNotModified),
           resourceOpts_(std::move(resourceOpts)),
           clientOpts_(std::move(clientOpts)) {}
 
@@ -185,6 +193,9 @@ public:
                                                 Callback cb) override {
         auto state = std::make_shared<RequestState>();
         state->cb = std::move(cb);
+        if (materializeNotModified_) {
+            state->withheld_prior_body = resource.priorData;
+        }
 
         // FileSource callbacks must run on the thread that issued request().
         // Capture the scheduler's weak binding while that scheduler is known to
@@ -245,6 +256,7 @@ public:
 
 private:
     std::shared_ptr<rust::Box<BoxedFileSource>> source_;
+    bool materializeNotModified_;
     mbgl::ResourceOptions resourceOpts_;
     mbgl::ClientOptions clientOpts_;
 };
@@ -280,11 +292,14 @@ void register_rust_file_source(FileSourceType source_type, rust::Box<BoxedFileSo
         rust_database_source_registered.store(true, std::memory_order_release);
     }
     auto shared_source = std::make_shared<rust::Box<BoxedFileSource>>(std::move(source));
+    const bool materialize_not_modified = source_type == FileSourceType::Network;
     mbgl::FileSourceManager::get()->registerFileSourceFactory(
         source_type,
-        [shared_source](const mbgl::ResourceOptions& ro, const mbgl::ClientOptions& co)
+        [shared_source, materialize_not_modified](const mbgl::ResourceOptions& ro,
+                                                  const mbgl::ClientOptions& co)
             -> std::unique_ptr<mbgl::FileSource> {
-            return std::make_unique<RustFileSource>(shared_source, ro.clone(), co.clone());
+            return std::make_unique<RustFileSource>(
+                shared_source, materialize_not_modified, ro.clone(), co.clone());
         });
 }
 

--- a/src/cpp/rust_file_source.h
+++ b/src/cpp/rust_file_source.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <string>
 
 namespace mln {
 namespace bridge {
@@ -34,6 +35,8 @@ struct RequestState {
   std::mutex response_mutex;
   std::optional<mbgl::Response> response;
   std::atomic<bool> cancelled{false};
+  // Cached body held until revalidation completes.
+  std::shared_ptr<const std::string> withheld_prior_body;
 };
 
 // Holds a forward's (cache-write) completion callback until `forward_complete`.

--- a/src/renderer/file_source/source.rs
+++ b/src/renderer/file_source/source.rs
@@ -27,6 +27,9 @@ pub trait FileSource: Send + Sync + 'static {
     /// Deliver the [`Response`] through `responder` — inline, or later from
     /// another thread. Return [`RequestHandle::Done`] when completed inline, or
     /// [`RequestHandle::pending`] with a cancel hook while work is in flight.
+    ///
+    /// For network requests, a 304 returns the cached body from
+    /// [`prior_data`](ResourceRequest::prior_data).
     fn request(&self, request: ResourceRequest, responder: Responder) -> RequestHandle;
 
     /// Store `response` for `request` (cache write).

--- a/tests/file_source_cache.rs
+++ b/tests/file_source_cache.rs
@@ -1,5 +1,4 @@
-//! Tests a custom ambient cache: a Rust `Database` source that serves responses
-//! forwarded from a Rust `Network` source
+//! Tests cache forwarding, cache hits, and 304 revalidation with Rust sources.
 
 use std::{
     collections::HashMap,
@@ -32,6 +31,7 @@ const STYLE_URL: &str = "https://example.invalid/cache-style.json";
 
 struct NetworkSource {
     hits: Arc<AtomicUsize>,
+    revalidations: Arc<AtomicUsize>,
 }
 
 struct DatabaseSource {
@@ -47,13 +47,19 @@ impl TokioFileSource for NetworkSource {
 
     async fn request(&self, request: ResourceRequest) -> Response {
         tokio::task::yield_now().await;
-        if request.url.ends_with("/cache-style.json") {
-            self.hits.fetch_add(1, Ordering::SeqCst);
+        self.hits.fetch_add(1, Ordering::SeqCst);
+        if request.prior_data.is_some() {
+            assert_eq!(request.prior_etag.as_deref(), Some(ETAG));
+            self.revalidations.fetch_add(1, Ordering::SeqCst);
+            Response::not_modified()
+                .with_etag(ETAG)
+                .with_must_revalidate(true)
+                .with_expires(SystemTime::UNIX_EPOCH + Duration::from_secs(1))
+        } else {
             Response::data(INLINE_STYLE.as_bytes().to_vec())
                 .with_etag(ETAG)
-                .with_expires(SystemTime::UNIX_EPOCH + Duration::from_secs(4_000_000_000))
-        } else {
-            Response::no_content()
+                .with_must_revalidate(true)
+                .with_expires(SystemTime::UNIX_EPOCH + Duration::from_secs(1))
         }
     }
 }
@@ -88,8 +94,10 @@ impl TokioFileSource for DatabaseSource {
     }
 }
 
-fn render_once() {
-    thread::spawn(|| {
+/// Renders on a separate thread so a wedge can time out.
+fn render_once(label: &'static str) {
+    let (done_tx, done_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
         let mut renderer = ImageRendererBuilder::new()
             .with_size(NonZeroU32::new(64).unwrap(), NonZeroU32::new(64).unwrap())
             .with_pixel_ratio(1.0)
@@ -108,28 +116,39 @@ fn render_once() {
                     .pitch(0.0),
             )
             .expect("render should succeed");
-    })
-    .join()
-    .expect("renderer thread should not panic");
+        drop(renderer);
+        let _ = done_tx.send(());
+    });
+    match done_rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(()) => handle.join().expect("renderer thread should not panic"),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            handle.join().expect("renderer thread should not panic");
+            panic!("{label}: renderer exited without reporting completion");
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            panic!("{label}: render did not complete within the timeout")
+        }
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn database_cache_serves_after_network_forward() {
+async fn database_cache_serves_and_revalidates_network_responses() {
     let network_hits = Arc::new(AtomicUsize::new(0));
+    let revalidations = Arc::new(AtomicUsize::new(0));
     let cache_hits = Arc::new(AtomicUsize::new(0));
     let store: Arc<Mutex<HashMap<String, Response>>> = Arc::new(Mutex::new(HashMap::new()));
     let (forwarded_tx, forwarded_rx) = mpsc::channel();
 
     register_tokio_file_source(
         FileSourceType::Network,
-        NetworkSource { hits: network_hits.clone() },
+        NetworkSource { hits: network_hits.clone(), revalidations: revalidations.clone() },
     );
     register_tokio_file_source(
         FileSourceType::Database,
         DatabaseSource { store: store.clone(), hits: cache_hits.clone(), forwarded: forwarded_tx },
     );
 
-    render_once();
+    render_once("initial load");
 
     // Wait for the cache write that mbgl forwards after the network response.
     forwarded_rx.recv_timeout(Duration::from_secs(5)).expect("the response should be forwarded");
@@ -151,10 +170,15 @@ async fn database_cache_serves_after_network_forward() {
     assert_eq!(stored.etag.as_deref(), Some(ETAG), "etag should round-trip through mbgl");
     assert!(stored.expires.is_some(), "expires should round-trip through mbgl");
 
-    render_once();
+    render_once("304 revalidation");
+    forwarded_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("the revalidated response should be forwarded");
 
     assert!(
         cache_hits.load(Ordering::SeqCst) >= 1,
-        "second render should be served from the Database cache",
+        "second render should revalidate the Database cache entry",
     );
+    assert_eq!(revalidations.load(Ordering::SeqCst), 1);
+    assert_eq!(network_hits.load(Ordering::SeqCst), 2);
 }

--- a/tests/file_source_cache.rs
+++ b/tests/file_source_cache.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::HashMap,
+    future::Future,
     num::NonZeroU32,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -72,9 +73,9 @@ impl TokioFileSource for DatabaseSource {
             && !request.url.starts_with("file://")
     }
 
-    async fn request(&self, request: ResourceRequest) -> Response {
+    fn request(&self, request: ResourceRequest) -> impl Future<Output = Response> {
         let cached = self.store.lock().unwrap().get(&request.url).cloned();
-        if let Some(response) = cached {
+        std::future::ready(if let Some(response) = cached {
             self.hits.fetch_add(1, Ordering::SeqCst);
             response
         } else {
@@ -82,7 +83,7 @@ impl TokioFileSource for DatabaseSource {
             let mut miss = Response::error(ErrorReason::NotFound, "cache miss");
             miss.no_content = true;
             miss
-        }
+        })
     }
 
     async fn forward(&self, request: ResourceRequest, response: Response) {

--- a/webgpu-shim/src/lib.rs
+++ b/webgpu-shim/src/lib.rs
@@ -6,6 +6,7 @@
  * Licensed under the Apache License, Version 2.0 or the MIT License, at your option.
  */
 
+#![recursion_limit = "256"]
 #![allow(missing_docs)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]


### PR DESCRIPTION
When a Network `FileSource` returns `Response::not_modified()` for a request with `prior_data`, the adapter must
return the cached body instead, matching the default `OnlineFileSource` behavior.

Otherwise, MLN never receives the cached body and rendering hangs.