### PR TITLE
fix: follow symlinks when collecting C++ bridge sources

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -371,6 +371,7 @@ fn build_bridge(
 
     // Compile C++ bridge sources.
     let mut cpp_files = walkdir::WalkDir::new(root.join(BRIDGE_CPP_DIR))
+        .follow_links(true)
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| e.file_type().is_file())


### PR DESCRIPTION
Some build systems vendor sources as symlink trees, in my case I'm using Naersk (Nix) to  build the crate.
Without this .follow_links(true) change, the build fails because, well, they're links.
This simple change fixes it and shouldn't affect anything else in any shape or form.

My usecase would get even better if a Nix flake or proper nixpkgs upstreaming happened, but that's for another day!